### PR TITLE
feat: secure env var logging in CI runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ repositories/
 .env
 runners/
 *.log
+gh_*
+runs.json
+cluster-ci-runs.log
+test_env.sh
+update_script.sh
+patch.txt
+patch_script.py
+repositories/

--- a/src/runner/run_research_pipeline.sh
+++ b/src/runner/run_research_pipeline.sh
@@ -106,6 +106,18 @@ if [ -f "$BASE_DIR/.env.secrets" ]; then
     set +a
     log_info "Secrets globaux chargés (.env.secrets)"
 fi
+
+log_info "Variables d'environnement disponibles :"
+while IFS='=' read -r name value; do
+    if [[ ! "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then continue; fi
+    if [[ -z "$value" ]]; then
+        log_info "   $name=(vide)"
+    else
+        first_chars="${value:0:3}"
+        log_info "   $name=${first_chars}***"
+    fi
+done < <(env | sort)
+
 if ! command -v uv &> /dev/null; then
     source "$HOME/.local/bin/env" || true
 fi


### PR DESCRIPTION
Affiche les variables d'environnement dans les logs du runner CI. Les valeurs sont masquées pour des raisons de sécurité, seuls les trois premiers caractères sont affichés, et les variables vides sont notées (vide). L'affichage des variables s'effectue après avoir sourcé les fichiers .env et .env.secrets.

---
*PR created automatically by Jules for task [9439266076485732161](https://jules.google.com/task/9439266076485732161) started by @hjamet*