### PR TITLE
Implementation of JIT Garbage Collector (LRU)

### DIFF
--- a/docs/index_architecture.md
+++ b/docs/index_architecture.md
@@ -2,4 +2,5 @@
 
 | Titre de la note | Courte Description | Dernière modif | Tag |
 |------------------|-------------------|----------------|-----|
-| *Les fichiers seront ajoutés au fur et à mesure du développement.* | - | - | - |
+| [JIT GC](tasks/jit_gc.md) | Garbage Collector basé sur LRU pour gérer l'espace disque. | 2024-05-22 | Infrastructure |
+| [Concurrency Management](tasks/concurrency_management.md) | Gestion de l'annulation des jobs obsolètes. | 2024-05-22 | Infrastructure |

--- a/docs/tasks/concurrency_management.md
+++ b/docs/tasks/concurrency_management.md
@@ -14,3 +14,6 @@ La discussion avec l'utilisateur a mené à la décision d'implémenter une annu
 *   L'option `cancel-in-progress` est activée (`true`).
 *   Le déclenchement de la CI reste actif pour les `push` sur les branches principales et les `pull_request`.
 *   Un nouveau commit ou une nouvelle action annule immédiatement toute exécution en cours pour le dépôt concerné.
+
+## 4. Relation avec le Garbage Collector JIT
+L'annulation agressive des jobs permet au Garbage Collector JIT de marquer plus rapidement les environnements comme `idle` (via le mécanisme de `trap EXIT` dans l'orchestrateur), facilitant ainsi la libération d'espace disque si nécessaire pour d'autres tâches prioritaires.

--- a/docs/tasks/jit_gc.md
+++ b/docs/tasks/jit_gc.md
@@ -1,0 +1,27 @@
+# JIT Garbage Collector (LRU)
+
+## 1. Contexte & Pourquoi
+Afin de préserver l'espace disque des machines de calcul tout en profitant de la vitesse du cache local, nous gérons dynamiquement les espaces de travail (workspaces). L'approche choisie est une suppression Just-In-Time (JIT) avant l'exécution de nouveaux jobs.
+
+## 2. Fonctionnement
+Le système s'appuie sur un registre local de métadonnées (`repositories/registry.json`) qui suit :
+- Le nom du projet (owner/repo).
+- La date de dernière exécution (Timestamp).
+- La taille sur le disque (octets).
+- Le statut (`running`, `idle`, ou `deleted`).
+
+### Politique de nettoyage (LRU)
+Avant chaque job, l'orchestrateur vérifie l'espace disque disponible sur la partition des dépôts.
+- **Seuil de sécurité :** 200 Go.
+- Si l'espace libre est inférieur à ce seuil, le GC identifie les projets marqués comme `idle`.
+- Il supprime les dossiers locaux en commençant par le plus ancien (Least Recently Used) jusqu'à ce que le seuil de 200 Go soit respecté.
+- Les projets en cours (`running`) ne sont jamais supprimés.
+
+## 3. Composants
+- `src/runner/gc_orchestrator.py` : Script Python gérant la logique du GC et du registre.
+- `src/runner/run_research_pipeline.sh` : Orchestrateur Shell intégrant les appels au GC.
+
+## 4. Intégration
+L'orchestrateur appelle `gc_orchestrator.py` aux moments clés :
+1. **Avant le job :** `run-gc` pour libérer l'espace et `update-running` pour marquer le projet actif.
+2. **Après le job (via trap EXIT) :** `update-idle` pour mettre à jour la taille occupée et marquer le projet comme inactif.

--- a/src/runner/gc_orchestrator.py
+++ b/src/runner/gc_orchestrator.py
@@ -1,0 +1,190 @@
+import os
+import json
+import shutil
+import sys
+import time
+import fcntl
+import subprocess
+from pathlib import Path
+
+# Config
+DEFAULT_FREE_SPACE_THRESHOLD_GB = 200
+FREE_SPACE_THRESHOLD_GB = int(os.environ.get("GC_FREE_SPACE_THRESHOLD_GB", DEFAULT_FREE_SPACE_THRESHOLD_GB))
+FREE_SPACE_THRESHOLD_BYTES = FREE_SPACE_THRESHOLD_GB * 1024 * 1024 * 1024
+REGISTRY_FILENAME = "registry.json"
+
+def get_base_dir():
+    # Assuming script is in src/runner/gc_orchestrator.py
+    return Path(__file__).parent.parent.parent.resolve()
+
+def get_repositories_dir():
+    return get_base_dir() / "repositories"
+
+def get_registry_path():
+    return get_repositories_dir() / REGISTRY_FILENAME
+
+def load_registry(f):
+    try:
+        f.seek(0)
+        content = f.read()
+        if not content:
+            return {}
+        return json.loads(content)
+    except Exception as e:
+        print(f"Error loading registry: {e}")
+        return {}
+
+def save_registry(f, registry):
+    f.seek(0)
+    f.truncate()
+    json.dump(registry, f, indent=4)
+    f.flush()
+    os.fsync(f.fileno())
+
+def get_dir_size(path):
+    """Calculates directory size using 'du -sb' if available, otherwise os.walk."""
+    try:
+        # Use -s for summary and -b for bytes
+        output = subprocess.check_output(["du", "-sb", str(path)], stderr=subprocess.DEVNULL)
+        return int(output.split()[0])
+    except (subprocess.CalledProcessError, FileNotFoundError, IndexError, ValueError):
+        # Fallback to os.walk
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                if not os.path.islink(fp):
+                    try:
+                        total_size += os.path.getsize(fp)
+                    except OSError:
+                        pass
+        return total_size
+
+def validate_project_name(project_name):
+    """Simple validation to ensure project_name is a relative path and doesn't escape repositories/."""
+    path = Path(project_name)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"Invalid project name: {project_name}")
+
+def update_running(project_name):
+    validate_project_name(project_name)
+    registry_path = get_registry_path()
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(registry_path, "a+") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            registry = load_registry(f)
+            registry[project_name] = registry.get(project_name, {})
+            registry[project_name].update({
+                "last_execution": time.time(),
+                "status": "running"
+            })
+            save_registry(f, registry)
+            print(f"Project {project_name} marked as running.")
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+def update_idle(project_name, project_path):
+    validate_project_name(project_name)
+    registry_path = get_registry_path()
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+    size = 0
+    if os.path.exists(project_path):
+        size = get_dir_size(project_path)
+
+    with open(registry_path, "a+") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            registry = load_registry(f)
+            if project_name not in registry:
+                registry[project_name] = {}
+
+            registry[project_name].update({
+                "status": "idle",
+                "size_bytes": size,
+                "last_execution": time.time()
+            })
+            save_registry(f, registry)
+            print(f"Project {project_name} marked as idle. Size: {size} bytes.")
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+def run_gc():
+    repo_dir = get_repositories_dir()
+    if not repo_dir.exists():
+        print("Repositories directory does not exist. No GC needed.")
+        return
+
+    usage = shutil.disk_usage(repo_dir)
+    free_space = usage.free
+
+    print(f"Free space: {free_space / (1024**3):.2f} GB (Threshold: {FREE_SPACE_THRESHOLD_GB} GB)")
+
+    if free_space < FREE_SPACE_THRESHOLD_BYTES:
+        print(f"Free space below threshold. Starting cleanup...")
+        registry_path = get_registry_path()
+        if not registry_path.exists():
+            print("Registry file not found. Nothing to clean.")
+            return
+
+        with open(registry_path, "a+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                registry = load_registry(f)
+
+                # Filter idle projects and sort by last_execution (oldest first)
+                idle_projects = [
+                    (name, data) for name, data in registry.items()
+                    if data.get("status") == "idle"
+                ]
+                idle_projects.sort(key=lambda x: x[1].get("last_execution", 0))
+
+                for project_name, data in idle_projects:
+                    if free_space >= FREE_SPACE_THRESHOLD_BYTES:
+                        break
+
+                    # Double check project name for safety before deletion
+                    validate_project_name(project_name)
+                    project_path = repo_dir / project_name
+
+                    if project_path.exists():
+                        print(f"Deleting oldest idle project: {project_name} at {project_path}")
+                        try:
+                            shutil.rmtree(project_path)
+                            # Update free space after deletion
+                            usage = shutil.disk_usage(repo_dir)
+                            free_space = usage.free
+                            data["size_bytes"] = 0
+                            data["status"] = "deleted"
+                            print(f"Deleted {project_name}. New free space: {free_space / (1024**3):.2f} GB")
+                        except Exception as e:
+                            print(f"Error deleting {project_name}: {e}")
+
+                save_registry(f, registry)
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+    else:
+        print("Sufficient free space available. No GC needed.")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python gc_orchestrator.py <command> [args]")
+        sys.exit(1)
+
+    command = sys.argv[1]
+
+    try:
+        if command == "update-running":
+            update_running(sys.argv[2])
+        elif command == "update-idle":
+            update_idle(sys.argv[2], sys.argv[3])
+        elif command == "run-gc":
+            run_gc()
+        else:
+            print(f"Unknown command: {command}")
+            sys.exit(1)
+    except Exception as e:
+        print(f"Error in {command}: {e}")
+        sys.exit(1)

--- a/src/runner/run_research_pipeline.sh
+++ b/src/runner/run_research_pipeline.sh
@@ -56,6 +56,17 @@ else
     REPO_URL="https://github.com/${TARGET_REPO}.git"
 fi
 
+# 1.5 JIT Garbage Collection & Metadata update
+log_info "[Etape 1.5/3] Gestion du ramasse-miettes (GC) JIT..."
+python3 "$BASE_DIR/src/runner/gc_orchestrator.py" run-gc
+python3 "$BASE_DIR/src/runner/gc_orchestrator.py" update-running "$TARGET_REPO"
+
+function update_status_idle() {
+    log_info "Mise à jour des métadonnées (statut idle)..."
+    python3 "$BASE_DIR/src/runner/gc_orchestrator.py" update-idle "$TARGET_REPO" "$BASE_DIR/repositories/$TARGET_REPO"
+}
+trap update_status_idle EXIT
+
 # 2. Gestion de l'état Git
 if [ ! -d "$REPO_BASENAME/.git" ]; then
     log_info "[Etape 2/3] Premier fetch du dépôt. Clonage en cours..."

--- a/src/runner/test_gc.py
+++ b/src/runner/test_gc.py
@@ -1,0 +1,136 @@
+import unittest
+import os
+import json
+import shutil
+from pathlib import Path
+import time
+import sys
+import fcntl
+import multiprocessing
+
+# Add src to path to import gc_orchestrator
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from src.runner import gc_orchestrator
+
+def run_update_running(project, test_base_dir, test_repo_dir):
+    # Setup same environment in child process
+    gc_orchestrator.get_base_dir = lambda: test_base_dir
+    gc_orchestrator.get_repositories_dir = lambda: test_repo_dir
+    gc_orchestrator.update_running(project)
+
+class TestGC(unittest.TestCase):
+    def setUp(self):
+        self.test_base_dir = Path("test_gc_root").resolve()
+        self.test_repo_dir = self.test_base_dir / "repositories"
+        self.test_repo_dir.mkdir(parents=True, exist_ok=True)
+
+        # Patch gc_orchestrator functions to use test dirs
+        self.original_get_base_dir = gc_orchestrator.get_base_dir
+        self.original_get_repositories_dir = gc_orchestrator.get_repositories_dir
+        gc_orchestrator.get_base_dir = lambda: self.test_base_dir
+        gc_orchestrator.get_repositories_dir = lambda: self.test_repo_dir
+
+    def tearDown(self):
+        # Restore original functions
+        gc_orchestrator.get_base_dir = self.original_get_base_dir
+        gc_orchestrator.get_repositories_dir = self.original_get_repositories_dir
+        if self.test_base_dir.exists():
+            shutil.rmtree(self.test_base_dir)
+
+    def test_registry_lifecycle(self):
+        project = "user/repo"
+        gc_orchestrator.update_running(project)
+
+        with open(gc_orchestrator.get_registry_path(), "r") as f:
+            registry = json.load(f)
+        self.assertIn(project, registry)
+        self.assertEqual(registry[project]["status"], "running")
+
+        # Create a dummy file to have some size
+        project_path = self.test_repo_dir / project
+        project_path.mkdir(parents=True, exist_ok=True)
+        with open(project_path / "data.txt", "w") as f:
+            f.write("hello world")
+
+        gc_orchestrator.update_idle(project, str(project_path))
+        with open(gc_orchestrator.get_registry_path(), "r") as f:
+            registry = json.load(f)
+        self.assertEqual(registry[project]["status"], "idle")
+        self.assertGreater(registry[project]["size_bytes"], 0)
+
+    def test_concurrency_locking(self):
+        project = "concurrency/test"
+        # First creation
+        gc_orchestrator.update_running(project)
+
+        registry_path = gc_orchestrator.get_registry_path()
+
+        # Manually lock the file
+        with open(registry_path, "a+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+
+            # Start a process that tries to update the registry
+            p = multiprocessing.Process(target=run_update_running, args=("other/proj", self.test_base_dir, self.test_repo_dir))
+            p.start()
+
+            # Wait a bit, it should be blocked
+            time.sleep(0.5)
+            self.assertTrue(p.is_alive())
+
+            # Unlock
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+            # Now it should finish
+            p.join(timeout=2)
+            self.assertFalse(p.is_alive())
+
+        with open(registry_path, "r") as f:
+            registry = json.load(f)
+        self.assertIn("other/proj", registry)
+
+    def test_validation(self):
+        with self.assertRaises(ValueError):
+            gc_orchestrator.update_running("/absolute/path")
+        with self.assertRaises(ValueError):
+            gc_orchestrator.update_running("../escape")
+
+    def test_gc_logic(self):
+        # Simulate low space
+        import unittest.mock
+        original_disk_usage = shutil.disk_usage
+        shutil.disk_usage = lambda path: unittest.mock.MagicMock(free=100 * 1024 * 1024 * 1024, total=1000 * 1024 * 1024 * 1024)
+
+        try:
+            projects = ["p1", "p2", "p3"]
+            for i, p in enumerate(projects):
+                p_path = self.test_repo_dir / p
+                p_path.mkdir(parents=True, exist_ok=True)
+                with open(p_path / "file.txt", "w") as f:
+                    f.write("data")
+
+                gc_orchestrator.update_idle(p, str(p_path))
+                # Adjust time
+                registry_path = gc_orchestrator.get_registry_path()
+                with open(registry_path, "r+") as f:
+                    fcntl.flock(f, fcntl.LOCK_EX)
+                    registry = json.load(f)
+                    registry[p]["last_execution"] = time.time() - (100 - i * 10)
+                    f.seek(0)
+                    f.truncate()
+                    json.dump(registry, f)
+                    fcntl.flock(f, fcntl.LOCK_UN)
+
+            gc_orchestrator.update_running("p2")
+            gc_orchestrator.run_gc()
+
+            with open(gc_orchestrator.get_registry_path(), "r") as f:
+                registry = json.load(f)
+            self.assertEqual(registry["p1"]["status"], "deleted")
+            self.assertEqual(registry["p3"]["status"], "deleted")
+            self.assertEqual(registry["p2"]["status"], "running")
+
+        finally:
+            shutil.disk_usage = original_disk_usage
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR implements a Just-In-Time (JIT) Garbage Collector (GC) based on a Least Recently Used (LRU) policy to manage disk space on calculation machines.

Key features:
- **Registry Management**: Tracks project name, last execution time, disk size, and status (running/idle) in `repositories/registry.json`.
- **LRU Eviction**: Automatically deletes oldest idle project workspaces when free disk space falls below a threshold (default: 200 GB).
- **Concurrency Safety**: Uses `fcntl` file locking to prevent race conditions during registry updates from concurrent jobs.
- **Integration**: Integrated into the main orchestrator script with `trap` handlers to ensure metadata updates even on job failure.
- **Configurability**: Threshold can be adjusted via `GC_FREE_SPACE_THRESHOLD_GB`.
- **Robustness**: Efficient size calculation using `du -sb` with fallback, and project name validation.

Documentation and tests are included.

Fixes #3

---
*PR created automatically by Jules for task [9730280521973577568](https://jules.google.com/task/9730280521973577568) started by @hjamet*