### PR TITLE
Implementation of Ephemeral Runner Pool (Process Manager)

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run Orchestrator
+      - name: Submit and Wait for Research Pipeline
         run: /usr/local/bin/cluster-ci-run "${{ github.repository }}" "${{ github.head_ref || github.ref_name }}" "${{ secrets.GITHUB_TOKEN }}"

--- a/src/cluster/setup_runner.sh
+++ b/src/cluster/setup_runner.sh
@@ -49,55 +49,49 @@ if [ -z "$GITHUB_PAT" ]; then
 fi
 
 # 3. Préparation du dossier contenant le runner
-# On crée un dossier dédié par repo pour pouvoir en gérer plusieurs sur le compte personnel
-RUNNER_DIR="runners/${TARGET//\//-}"
-mkdir -p "$RUNNER_DIR"
-cd "$RUNNER_DIR"
+# On télécharge une fois le runner dans un dossier template
+TEMPLATE_DIR="runners/template"
+mkdir -p "$TEMPLATE_DIR"
 
-if [ ! -f "config.sh" ]; then
+if [ ! -f "$TEMPLATE_DIR/config.sh" ]; then
     echo "⬇️ Téléchargement du binaire Runner GitHub Actions..."
     RUNNER_VERSION="2.321.0"
     curl -o actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
-    tar xzf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+    tar xzf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz -C "$TEMPLATE_DIR"
     rm actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
 fi
 
-# 4. Enregistrement dynamique via l'API GitHub
-if [[ "$TARGET" == *"/"* ]]; then
-    API_URL="https://api.github.com/repos/$TARGET/actions/runners/registration-token"
-else
-    API_URL="https://api.github.com/orgs/$TARGET/actions/runners/registration-token"
-fi
-
-echo "🔑 Récupération du Registration Token temporaire via API ($API_URL)..."
-RESPONSE=$(curl -sL \
-  -X POST \
-  -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer $GITHUB_PAT" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  $API_URL)
-
-# Parse sécurisé avec python3 standard
-REG_TOKEN=$(echo "$RESPONSE" | python3 -c "import sys, json; print(json.load(sys.stdin).get('token', ''))")
-
-if [ -z "$REG_TOKEN" ]; then
-    echo "❌ Échec de récupération du token. L'API a répondu: $RESPONSE"
-    echo "Vérifiez que votre PAT comporte bien le scope 'repo' et que le dépôt existe."
-    exit 1
-fi
-
-echo "⚙️ Configuration du Runner local..."
-./config.sh --url https://github.com/$TARGET --token $REG_TOKEN --unattended --replace --name "cluster-local-${TARGET//\//-}" --labels self-hosted,cluster-ci
-
-echo "✅ Runner installé et configuré avec succès dans $RUNNER_DIR"
-echo "👉 Pour le démarrer manuellement (Test DEV) : cd $RUNNER_DIR && ./run.sh"
+# On prépare 2 slots pour les runners éphémères
+for i in 1 2; do
+    SLOT_DIR="runners/slot$i"
+    if [ ! -d "$SLOT_DIR" ]; then
+        echo "📂 Initialisation du slot $i..."
+        cp -r "$TEMPLATE_DIR" "$SLOT_DIR"
+    fi
+done
 
 # 5. Installation Systemd
 if [ "$ROLE" == "headnode" ]; then
-    echo "⚙️ Installation du service systemd pour le Runner GitHub..."
-    sudo ./svc.sh install
-    sudo ./svc.sh start
-    echo "🚀 Service GitHub Runner installé et démarré."
+    echo "⚙️ Installation du service systemd pour le Runner Manager éphémère..."
+
+    # Création du service systemd pour le runner manager
+    cat <<EOF | sudo tee /etc/systemd/system/cluster-runner-manager.service
+[Unit]
+Description=Cluster-CI Ephemeral Runner Manager
+After=network.target
+
+[Service]
+Type=simple
+User=$USER
+WorkingDirectory=$BASE_DIR
+Environment="TARGET_REPO=$TARGET"
+Environment="GITHUB_PAT=$GITHUB_PAT"
+ExecStart=$(which python3) $BASE_DIR/src/scheduler/runner_manager.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
 
     echo "⚙️ Configuration du Scheduler Headnode..."
     # Installation des dépendances pour le scheduler
@@ -138,9 +132,9 @@ WantedBy=multi-user.target
 EOF
 
     sudo systemctl daemon-reload
-    sudo systemctl enable cluster-scheduler cluster-scheduler-loop
-    sudo systemctl start cluster-scheduler cluster-scheduler-loop
-    echo "🚀 Services Scheduler démarrés."
+    sudo systemctl enable cluster-scheduler cluster-scheduler-loop cluster-runner-manager
+    sudo systemctl start cluster-scheduler cluster-scheduler-loop cluster-runner-manager
+    echo "🚀 Services Scheduler et Runner Manager démarrés."
 
 else
     echo "⚙️ Configuration du Worker Agent..."

--- a/src/runner/run_research_pipeline.sh
+++ b/src/runner/run_research_pipeline.sh
@@ -16,6 +16,14 @@ SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
 BASE_DIR="$( cd "$( dirname "$SCRIPT_PATH" )/../.." >/dev/null 2>&1 && pwd )"
 cd "$BASE_DIR"
 
+# Mode délégation : Si on n'est pas explicitement en mode exécuteur,
+# on délègue la tâche à l'ordonnanceur via submit_job.py
+if [ "$CLUSTER_CI_MODE" != "executor" ]; then
+    echo "🌐 Mode Délégation activé. Soumission du job à l'ordonnanceur..."
+    python3 "$BASE_DIR/src/scheduler/submit_job.py" "$TARGET_REPO" "$TARGET_BRANCH"
+    exit $?
+fi
+
 REPO_WORK_DIR="repositories/$TARGET_REPO"
 
 # Pipe toute la sortie (stdout et stderr) vers la console ET vers un fichier log local

--- a/src/scheduler/runner_manager.py
+++ b/src/scheduler/runner_manager.py
@@ -1,0 +1,115 @@
+import os
+import subprocess
+import time
+import requests
+import logging
+import threading
+import sys
+from pathlib import Path
+
+# Configuration de logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] slot=%(slot)s: %(message)s',
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
+
+class RunnerManager:
+    def __init__(self, target_repo, github_pat, base_dir, num_slots=2):
+        self.target_repo = target_repo
+        self.github_pat = github_pat
+        self.base_dir = Path(base_dir)
+        self.runners_dir = self.base_dir / "runners"
+        self.num_slots = num_slots
+        self.runner_name_prefix = f"cluster-local-{target_repo.replace('/', '-')}"
+
+    def get_registration_token(self):
+        """Récupère un nouveau token d'enregistrement via l'API GitHub."""
+        if "/" in self.target_repo:
+            api_url = f"https://api.github.com/repos/{self.target_repo}/actions/runners/registration-token"
+        else:
+            api_url = f"https://api.github.com/orgs/{self.target_repo}/actions/runners/registration-token"
+
+        response = requests.post(
+            api_url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.github_pat}",
+                "X-GitHub-Api-Version": "2022-11-28"
+            }
+        )
+        response.raise_for_status()
+        return response.json()["token"]
+
+    def run_slot(self, slot_id):
+        """Gère le cycle de vie d'un runner éphémère pour un slot donné."""
+        slot_dir = self.runners_dir / f"slot{slot_id}"
+        logger = logging.LoggerAdapter(logging.getLogger(__name__), {'slot': slot_id})
+
+        while True:
+            try:
+                logger.info("Préparation d'un nouveau runner éphémère...")
+
+                # 1. Obtenir un token
+                token = self.get_registration_token()
+
+                # 2. Configurer le runner
+                runner_name = f"{self.runner_name_prefix}-slot{slot_id}"
+                config_cmd = [
+                    "./config.sh",
+                    "--url", f"https://github.com/{self.target_repo}",
+                    "--token", token,
+                    "--unattended",
+                    "--replace",
+                    "--name", runner_name,
+                    "--labels", "self-hosted,cluster-ci",
+                    "--ephemeral"
+                ]
+
+                logger.info(f"Configuration du runner {runner_name}...")
+                subprocess.run(config_cmd, cwd=slot_dir, check=True, capture_output=True)
+
+                # 3. Lancer le runner
+                logger.info("Lancement du runner...")
+                # run.sh bloque jusqu'à ce que le job soit fini ou que le runner soit arrêté
+                process = subprocess.Popen(["./run.sh"], cwd=slot_dir)
+                process.wait()
+
+                logger.info(f"Le runner s'est arrêté avec le code {process.returncode}. Redémarrage imminent...")
+
+            except Exception as e:
+                logger.error(f"Erreur dans le cycle du runner : {e}")
+                time.sleep(10) # Attendre un peu avant de réessayer en cas d'erreur fatale
+
+    def start(self):
+        threads = []
+        for i in range(1, self.num_slots + 1):
+            t = threading.Thread(target=self.run_slot, args=(i,))
+            t.daemon = True
+            t.start()
+            threads.append(t)
+
+        logger = logging.LoggerAdapter(logging.getLogger(__name__), {'slot': 'MANAGER'})
+        logger.info(f"Gestionnaire de runners démarré avec {self.num_slots} slots pour {self.target_repo}")
+
+        # Maintenir le thread principal vivant
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            logger.info("Arrêt du gestionnaire...")
+
+if __name__ == "__main__":
+    target = os.environ.get("TARGET_REPO")
+    pat = os.environ.get("GITHUB_PAT")
+
+    if not target or not pat:
+        print("Erreur : TARGET_REPO et GITHUB_PAT doivent être définis en variables d'environnement.")
+        sys.exit(1)
+
+    # On assume que le script est dans src/scheduler/
+    script_dir = Path(__file__).resolve().parent
+    base_dir = script_dir.parent.parent
+
+    manager = RunnerManager(target, pat, base_dir)
+    manager.start()

--- a/src/scheduler/worker_agent.py
+++ b/src/scheduler/worker_agent.py
@@ -84,6 +84,7 @@ def execute_job(job):
         "sudo", "systemd-run", "--scope", "--quiet",
         f"--property=MemoryMax={memory_limit}",
         f"--property=MemorySwapMax={memory_limit}",
+        "--setenv=CLUSTER_CI_MODE=executor",
         "cluster-ci-run", repo, branch
     ]
 


### PR DESCRIPTION
This PR implements the "Ephemeral Runner Pool" (Process Manager) on the Headnode.

Key changes:
1.  **Runner Manager:** A new Python script `src/scheduler/runner_manager.py` manages exactly 2 slots of GitHub Actions runners. It automatically fetches new registration tokens and restarts runners with the `--ephemeral` flag after they finish a job.
2.  **Delegation Mode:** `run_research_pipeline.sh` now detects if it's running as a "submitter" or an "executor". On the headnode, it submits the job to the scheduler and waits for completion. On workers, it executes the actual DVC pipeline.
3.  **Worker Agent Update:** The `worker_agent.py` now injects `CLUSTER_CI_MODE=executor` when launching the pipeline via `systemd-run`.
4.  **Setup Integration:** `setup_runner.sh` has been updated to install the `cluster-runner-manager.service` on the headnode instead of a static runner service. It also handles slot-based directory preparation.
5.  **Workflow Update:** The GitHub workflow step has been renamed to "Submit and Wait for Research Pipeline" to better reflect the new behavior.

These changes prevent blocking the GitHub queue and allow for better integration with the local scheduler.

Fixes #7

---
*PR created automatically by Jules for task [4061314625566916167](https://jules.google.com/task/4061314625566916167) started by @hjamet*