### PR TITLE
Replace Kernel OOM with Software Watchdog (psutil) in Worker

### DIFF
--- a/docs/index_architecture.md
+++ b/docs/index_architecture.md
@@ -21,7 +21,9 @@ L'allocation des jobs repose sur un algorithme de **Bin-Packing** basé sur la m
 2. L'ordonnanceur maintient une vue en temps réel de la RAM disponible sur chaque Worker.
 3. Le job est assigné au premier Worker ayant assez de RAM disponible, ou mis en attente si aucune ressource n'est libre.
 
-### Isolation et Protection (Protection OOM Artificielle)
-Pour garantir la stabilité des Workers, chaque job est exécuté via `systemd-run`.
-- **Cgroups :** Utilisation des limites `MemoryMax` et `MemorySwapMax`.
-- **Comportement :** Si un job dépasse la RAM qu'il a déclarée, le kernel (via systemd) tue immédiatement le processus. Cela évite les saturations système ("OOM Killer" global) et protège les autres jobs ou services tournant sur la même machine.
+### Isolation et Protection (Watchdog Mémoire Logiciel)
+Pour garantir la stabilité des Workers, chaque job est surveillé par un **Watchdog Logiciel** basé sur la librairie `psutil`.
+
+- **Mesure Récursive :** À intervalles réguliers (toutes les 2 secondes), le Worker calcule la somme de la mémoire physique (RSS) du processus de calcul et de tous ses processus enfants (par ex. sous-processus DVC).
+- **Interruption UX :** Si la somme dépasse la limite de RAM déclarée dans `.cluster-ci`, le Worker tue immédiatement l'arbre de processus.
+- **Feedback GitHub :** Un message d'erreur explicite est affiché sur la sortie standard d'erreur (stderr), permettant au chercheur de savoir exactement pourquoi son job a échoué et combien de RAM a été consommée par rapport à sa réservation.

--- a/docs/tasks/concurrency_management.md
+++ b/docs/tasks/concurrency_management.md
@@ -5,15 +5,22 @@ Lors de l'exécution de jobs de recherche longs, il est possible que plusieurs P
 
 La discussion avec l'utilisateur a mené à la décision d'implémenter une annulation agressive au niveau du dépôt complet. Comme l'annulation d'un job GitHub Actions ne déclenche pas de notification d'échec (fail), cela permet d'interrompre les jobs obsolètes sans "réveiller" inutilement l'agent Joules, évitant ainsi un effet de ping-pong permanent entre plusieurs branches ou versions.
 
-## 2. Fichiers Concernés
+## 2. Protection Mémoire (Watchdog)
+Afin d'offrir une meilleure expérience utilisateur et de s'affranchir des contraintes liées aux privilèges administrateur (`sudo systemd-run`), l'isolation de la RAM est gérée par un watchdog applicatif.
+
+*   **Mécanisme** : Le Worker monitore récursivement l'utilisation de la RAM de l'arbre de processus du job.
+*   **Action** : En cas de dépassement de la limite fixée dans `.cluster-ci`, le job est arrêté avec un code d'erreur 137.
+*   **UX** : Un message explicite est envoyé sur stderr pour s'afficher en rouge dans l'interface GitHub Actions, indiquant la consommation réelle vs la limite réservée.
+
+## 3. Fichiers Concernés
 - `install.sh` : Modèle de workflow GitHub Actions injecté dans les projets clients.
 
-## 3. Objectifs (Definition of Done)
+## 4. Objectifs (Definition of Done)
 *   Le script `install.sh` injecte désormais un bloc `concurrency` dans le fichier `.github/workflows/cluster-ci.yml`.
 *   Le groupe de concurrence est défini sur le dépôt complet (`${{ github.repository }}`).
 *   L'option `cancel-in-progress` est activée (`true`).
 *   Le déclenchement de la CI reste actif pour les `push` sur les branches principales et les `pull_request`.
 *   Un nouveau commit ou une nouvelle action annule immédiatement toute exécution en cours pour le dépôt concerné.
 
-## 4. Relation avec le Garbage Collector JIT
+## 5. Relation avec le Garbage Collector JIT
 L'annulation agressive des jobs permet au Garbage Collector JIT de marquer plus rapidement les environnements comme `idle` (via le mécanisme de `trap EXIT` dans l'orchestrateur), facilitant ainsi la libération d'espace disque si nécessaire pour d'autres tâches prioritaires.

--- a/src/scheduler/worker_agent.py
+++ b/src/scheduler/worker_agent.py
@@ -1,6 +1,7 @@
 import time
 import requests
 import os
+import sys
 import socket
 import psutil
 import subprocess
@@ -76,29 +77,59 @@ def execute_job(job):
     repo = job['repo']
     branch = job['branch']
     ram_limit_gb = job['ram_required_gb']
+    ram_limit_bytes = ram_limit_gb * (1024**3)
 
     logger.info(f"Executing job {job_id} for {repo}@{branch} with {ram_limit_gb}GB limit")
     update_job_status(job_id, 'running')
 
-    # Use systemd-run for memory isolation
     # We call the cluster-ci-run command which is supposed to be in /usr/local/bin/cluster-ci-run
-    # Note: In a real worker, we need to make sure this script is present.
+    cmd = ["/usr/local/bin/cluster-ci-run", repo, branch]
 
-    memory_limit = f"{int(ram_limit_gb * 1024)}M"
-
-    cmd = [
-        "sudo", "systemd-run", "--scope", "--quiet",
-        f"--property=MemoryMax={memory_limit}",
-        f"--property=MemorySwapMax={memory_limit}",
-        "--setenv=CLUSTER_CI_MODE=executor",
-        "cluster-ci-run", repo, branch
-    ]
+    env = os.environ.copy()
+    env["CLUSTER_CI_MODE"] = "executor"
 
     try:
-        process = subprocess.Popen(cmd)
+        process = subprocess.Popen(cmd, env=env)
+        oom_triggered = False
+
+        # Watchdog loop
+        while process.poll() is None:
+            try:
+                parent = psutil.Process(process.pid)
+                # RSS of parent
+                total_rss = parent.memory_info().rss
+                # RSS of all children recursively
+                for child in parent.children(recursive=True):
+                    try:
+                        total_rss += child.memory_info().rss
+                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                        continue
+
+                if total_rss > ram_limit_bytes:
+                    oom_triggered = True
+                    total_rss_gb = total_rss / (1024**3)
+                    error_msg = f"❌ [OOM ARTIFICIEL CLUSTER] Exécution interrompue ! Vous aviez réservé {ram_limit_gb} Go de RAM dans '.cluster-ci', or votre pipeline vient d'atteindre {total_rss_gb:.2f} Go. Veuillez augmenter votre réservation.\n"
+                    sys.stderr.write(error_msg)
+                    sys.stderr.flush()
+
+                    # Kill the process tree
+                    for child in parent.children(recursive=True):
+                        try:
+                            child.terminate()
+                        except psutil.NoSuchProcess:
+                            pass
+                    parent.terminate()
+                    break
+            except psutil.NoSuchProcess:
+                break
+
+            time.sleep(2)
+
         exit_code = process.wait()
 
-        if exit_code == 0:
+        if oom_triggered:
+            update_job_status(job_id, 'failed', 137)
+        elif exit_code == 0:
             update_job_status(job_id, 'completed', exit_code)
         else:
             update_job_status(job_id, 'failed', exit_code)


### PR DESCRIPTION
This PR replaces the previous kernel-level memory isolation (via `systemd-run` and cgroups) with a more flexible and user-friendly software watchdog. 

Key changes:
1. **Worker Agent Upgrade**: The `execute_job` function in `src/scheduler/worker_agent.py` now uses `psutil` to monitor the Resident Set Size (RSS) of the whole process tree (including children) every 2 seconds.
2. **Recursive Monitoring**: It correctly handles DVC-launched subprocesses by summing memory usage across the entire tree.
3. **Improved UX**: If a job exceeds its reserved RAM, it is terminated and a clear error message is printed to `stderr`: `❌ [OOM ARTIFICIEL CLUSTER] Exécution interrompue ! Vous aviez réservé {X} Go de RAM dans '.cluster-ci', or votre pipeline vient d'atteindre {Y} Go. Veuillez augmenter votre réservation.`
4. **No Root Required**: By removing `sudo systemd-run`, the worker agent can now run without administrator privileges.
5. **Documentation**: Updated architecture and concurrency management docs to describe the new mechanism.

Tests performed:
- Validated with a dummy memory-hogging script that the watchdog correctly identifies the overflow, kills the process tree, and reports the error.
- Verified that normal jobs still complete successfully.
- Ran existing flow tests to ensure no regressions.

Fixes #15

---
*PR created automatically by Jules for task [1907924010199457007](https://jules.google.com/task/1907924010199457007) started by @hjamet*