### PR TITLE
Unification de l'installation via curl (One-Liner) et mise à jour du README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,17 @@ curl -sSL https://raw.githubusercontent.com/UNIL-Henri/cluster-ci/main/install.s
 L'installation se fait via un "One-Liner" curl qui configure automatiquement l'environnement et les services systemd.
 
 #### 1. Installer le Headnode (Ordonnanceur)
-Le Headnode gère la file d'attente des jobs et les runners éphémères.
+Le Headnode gère la file d'attente des jobs et les runners éphémères. Le script vous demandera votre **GitHub PAT** et la cible à surveiller.
 ```bash
-export GITHUB_PAT="ghp_xxxx"
-curl -sSL https://raw.githubusercontent.com/UNIL-Henri/cluster-ci/main/install.sh | bash -s -- headnode "owner/repo"
+curl -sSL https://raw.githubusercontent.com/UNIL-Henri/cluster-ci/main/install.sh | bash -s -- headnode
 ```
 
 #### 2. Installer un Worker (Exécuteur)
-Les Workers s'enregistrent auprès du Headnode pour exécuter les calculs.
+Une fois le Headnode installé, il vous fournira une commande prête à l'emploi à exécuter sur vos Workers. Alternativement, vous pouvez lancer l'installation manuellement :
 ```bash
-export HEADNODE_URL="http://ip-du-headnode:5000"
 curl -sSL https://raw.githubusercontent.com/UNIL-Henri/cluster-ci/main/install.sh | bash -s -- worker
 ```
+Le script vous demandera l'**URL du Headnode** et le **Token du Cluster** généré lors de l'installation du Headnode.
 
 #### Configuration Post-Installation
 Une fois installé, vous pouvez ajouter des secrets (GCP, HuggingFace) dans le fichier `.env.secrets` situé dans le dossier d'installation (par défaut `~/cluster-ci`).

--- a/README.md
+++ b/README.md
@@ -10,31 +10,31 @@ Pour intégrer un projet de recherche au cluster, exécutez la commande suivante
 curl -sSL https://raw.githubusercontent.com/UNIL-Henri/cluster-ci/main/install.sh | bash
 ```
 
-### Côté Serveur (Machine Ubuntu / Cluster)
-1. Clonez ce dépôt.
-2. Configurez vos variables d'environnement à la racine du dépôt :
-   - Fichier **`.env`** : Contient le `GITHUB_PAT` et les configurations générales.
-   - Fichier **`.env.secrets`** (optionnel) : Contient les tokens d'API et credentials Cloud.
-   
-   **Variables recommandées :**
-   - `GITHUB_PAT` : Token GitHub avec accès `repo` et `workflow`.
-   - `GCP_CREDENTIALS` : (JSON minifié sur une ligne) Credentials Google Drive.
-   - `GCP_TOKEN` : (JSON minifié sur une ligne) Token OAuth Google Drive.
-   - `HF_TOKEN` : Token HuggingFace pour l'accès aux modèles.
+### Déploiement du Cluster (Headnode & Workers)
 
-3. Lancez l'installation du runner :
+L'installation se fait via un "One-Liner" curl qui configure automatiquement l'environnement et les services systemd.
+
+#### 1. Installer le Headnode (Ordonnanceur)
+Le Headnode gère la file d'attente des jobs et les runners éphémères.
 ```bash
-./src/cluster/setup_runner.sh owner/repo
-# OU pour cibler une Organisation complète :
-./src/cluster/setup_runner.sh nom_organisation
+export GITHUB_PAT="ghp_xxxx"
+curl -sSL https://raw.githubusercontent.com/UNIL-Henri/cluster-ci/main/install.sh | bash -s -- headnode "owner/repo"
 ```
-Le script installera automatiquement le runner et l'enregistrera en tant que service `systemd`. Les fichiers `.env` seront automatiquement chargés par le runner lors de chaque job.
 
-4. Pour tout désinstaller proprement (service systemd, suppression sur GitHub, nettoyage local) :
+#### 2. Installer un Worker (Exécuteur)
+Les Workers s'enregistrent auprès du Headnode pour exécuter les calculs.
 ```bash
+export HEADNODE_URL="http://ip-du-headnode:5000"
+curl -sSL https://raw.githubusercontent.com/UNIL-Henri/cluster-ci/main/install.sh | bash -s -- worker
+```
+
+#### Configuration Post-Installation
+Une fois installé, vous pouvez ajouter des secrets (GCP, HuggingFace) dans le fichier `.env.secrets` situé dans le dossier d'installation (par défaut `~/cluster-ci`).
+
+Pour tout désinstaller proprement (services systemd, nettoyage local) :
+```bash
+cd ~/cluster-ci
 ./src/cluster/uninstall_runner.sh owner/repo
-# OU pour l'Organisation :
-./src/cluster/uninstall_runner.sh nom_organisation
 ```
 
 ## Description détaillée

--- a/install.sh
+++ b/install.sh
@@ -15,22 +15,43 @@ if [[ "$ROLE" == "headnode" || "$ROLE" == "worker" ]]; then
     INSTALL_DIR=${INSTALL_DIR:-"$HOME/cluster-ci"}
     REPO_URL="https://github.com/UNIL-Henri/cluster-ci.git"
 
+    # Charger l'existant si disponible
+    if [ -f "$INSTALL_DIR/.env" ]; then
+        # On extrait proprement pour éviter de sourcer n'importe quoi
+        [ -z "$GITHUB_PAT" ] && GITHUB_PAT=$(grep "^GITHUB_PAT=" "$INSTALL_DIR/.env" | cut -d= -f2- | tr -d '"' | tr -d "'")
+        [ -z "$HEADNODE_URL" ] && HEADNODE_URL=$(grep "^HEADNODE_URL=" "$INSTALL_DIR/.env" | cut -d= -f2- | tr -d '"' | tr -d "'")
+        [ -z "$CLUSTER_TOKEN" ] && CLUSTER_TOKEN=$(grep "^CLUSTER_TOKEN=" "$INSTALL_DIR/.env" | cut -d= -f2- | tr -d '"' | tr -d "'")
+    fi
+
     if [ "$ROLE" == "headnode" ]; then
         if [ -z "$GITHUB_PAT" ]; then
-            echo "❌ Erreur : GITHUB_PAT est requis pour installer un headnode."
-            echo "Usage: GITHUB_PAT=your_token bash install.sh headnode target_repo"
-            exit 1
+            echo "🔑 GITHUB_PAT non détecté."
+            read -rs -p "Veuillez entrer votre GitHub PAT (avec accès repo & workflow) : " GITHUB_PAT
+            echo ""
         fi
         TARGET_REPO=$2
         if [ -z "$TARGET_REPO" ]; then
-            echo "❌ Erreur : TARGET_REPO est requis pour installer un headnode."
-            echo "Usage: GITHUB_PAT=your_token bash install.sh headnode target_repo"
+            echo "🎯 Cible non détectée (owner/repo ou organisation)."
+            read -p "Veuillez entrer la cible GitHub à surveiller : " TARGET_REPO
+        fi
+
+        if [ -z "$GITHUB_PAT" ] || [ -z "$TARGET_REPO" ]; then
+            echo "❌ Erreur : GITHUB_PAT et TARGET_REPO sont obligatoires pour un headnode."
             exit 1
         fi
     else
         if [ -z "$HEADNODE_URL" ]; then
-            echo "❌ Erreur : HEADNODE_URL est requis pour installer un worker."
-            echo "Usage: HEADNODE_URL=http://... bash install.sh worker"
+            echo "🔗 HEADNODE_URL non détecté."
+            read -p "Veuillez entrer l'URL du Headnode (ex: http://192.168.1.10:5000) : " HEADNODE_URL
+        fi
+        if [ -z "$CLUSTER_TOKEN" ]; then
+            echo "🔑 CLUSTER_TOKEN non détecté (requis pour s'authentifier auprès du Headnode)."
+            read -rs -p "Veuillez entrer le Token du Cluster : " CLUSTER_TOKEN
+            echo ""
+        fi
+
+        if [ -z "$HEADNODE_URL" ] || [ -z "$CLUSTER_TOKEN" ]; then
+            echo "❌ Erreur : HEADNODE_URL et CLUSTER_TOKEN sont obligatoires pour un worker."
             exit 1
         fi
     fi
@@ -55,16 +76,25 @@ if [[ "$ROLE" == "headnode" || "$ROLE" == "worker" ]]; then
         local var_value=$2
         if [ -n "$var_value" ]; then
             if grep -q "^$var_name=" "$TOUCH_ENV"; then
-                # On utilise une version compatible macOS/Linux de sed pour le remplacement in-place
-                sed -i "s|^$var_name=.*|$var_name=$var_value|" "$TOUCH_ENV"
+                # Remplacement portable de sed -i (compatible macOS/Linux)
+                local tmp_env=$(mktemp)
+                grep -v "^$var_name=" "$TOUCH_ENV" > "$tmp_env"
+                echo "$var_name=$var_value" >> "$tmp_env"
+                mv "$tmp_env" "$TOUCH_ENV"
             else
                 echo "$var_name=$var_value" >> "$TOUCH_ENV"
             fi
         fi
     }
 
+    if [ "$ROLE" == "headnode" ] && [ -z "$CLUSTER_TOKEN" ] && [ ! -f "$INSTALL_DIR/.env" ]; then
+        # Génération d'un token aléatoire pour le cluster
+        CLUSTER_TOKEN=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32)
+    fi
+
     update_env_var "GITHUB_PAT" "$GITHUB_PAT"
     update_env_var "HEADNODE_URL" "$HEADNODE_URL"
+    update_env_var "CLUSTER_TOKEN" "$CLUSTER_TOKEN"
 
     # 3. Exécution du setup local
     echo "🚀 Lancement de l'installation système..."
@@ -72,6 +102,15 @@ if [[ "$ROLE" == "headnode" || "$ROLE" == "worker" ]]; then
     bash src/cluster/setup_runner.sh "$TARGET_REPO" "$ROLE"
 
     echo "✅ Déploiement du $ROLE terminé avec succès dans $INSTALL_DIR."
+
+    if [ "$ROLE" == "headnode" ]; then
+        IP_ADDR=$(hostname -I | awk '{print $1}')
+        echo ""
+        echo "🎉 Votre Headnode est prêt !"
+        echo "👉 Pour ajouter des Workers, utilisez la commande suivante sur vos autres machines :"
+        echo "CLUSTER_TOKEN=\"$CLUSTER_TOKEN\" HEADNODE_URL=\"http://$IP_ADDR:5000\" curl -sSL $REPO_URL/raw/main/install.sh | bash -s -- worker"
+        echo ""
+    fi
     exit 0
 
 else

--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,94 @@
 #!/bin/bash
 set -e
 
-echo "🚀 Cluster-CI : Installation Client"
+ROLE=$1
 
-# 1. Vérification environnement Git
-if [ ! -d ".git" ]; then
-    echo "❌ Erreur : Ce script doit être exécuté à la racine d'un dépôt Git."
-    exit 1
-fi
+if [[ "$ROLE" == "headnode" || "$ROLE" == "worker" ]]; then
+    # --- Infrastructure Deployment (Dispatcher) ---
+    echo "🏗️  Cluster-CI : Déploiement de l'Infrastructure ($ROLE)"
 
-# 2. Injection du workflow GitHub Actions
-echo "📦 Injection du workflow GitHub Actions..."
-mkdir -p .github/workflows
+    if ! command -v git &> /dev/null; then
+        echo "❌ Erreur : git n'est pas installé sur cette machine."
+        exit 1
+    fi
 
-cat <<EOF > .github/workflows/cluster-ci.yml
+    INSTALL_DIR=${INSTALL_DIR:-"$HOME/cluster-ci"}
+    REPO_URL="https://github.com/UNIL-Henri/cluster-ci.git"
+
+    if [ "$ROLE" == "headnode" ]; then
+        if [ -z "$GITHUB_PAT" ]; then
+            echo "❌ Erreur : GITHUB_PAT est requis pour installer un headnode."
+            echo "Usage: GITHUB_PAT=your_token bash install.sh headnode target_repo"
+            exit 1
+        fi
+        TARGET_REPO=$2
+        if [ -z "$TARGET_REPO" ]; then
+            echo "❌ Erreur : TARGET_REPO est requis pour installer un headnode."
+            echo "Usage: GITHUB_PAT=your_token bash install.sh headnode target_repo"
+            exit 1
+        fi
+    else
+        if [ -z "$HEADNODE_URL" ]; then
+            echo "❌ Erreur : HEADNODE_URL est requis pour installer un worker."
+            echo "Usage: HEADNODE_URL=http://... bash install.sh worker"
+            exit 1
+        fi
+    fi
+
+    # 1. Clonage ou mise à jour du dépôt
+    if [ ! -d "$INSTALL_DIR" ]; then
+        echo "📂 Clonage du dépôt dans $INSTALL_DIR..."
+        git clone "$REPO_URL" "$INSTALL_DIR"
+    else
+        echo "📂 Mise à jour du dépôt dans $INSTALL_DIR..."
+        cd "$INSTALL_DIR" && git pull && cd - > /dev/null
+    fi
+
+    # 2. Configuration du .env (mise à jour sélective)
+    echo "📝 Configuration des variables d'environnement..."
+    mkdir -p "$INSTALL_DIR"
+    TOUCH_ENV="$INSTALL_DIR/.env"
+    [ ! -f "$TOUCH_ENV" ] && touch "$TOUCH_ENV"
+
+    update_env_var() {
+        local var_name=$1
+        local var_value=$2
+        if [ -n "$var_value" ]; then
+            if grep -q "^$var_name=" "$TOUCH_ENV"; then
+                # On utilise une version compatible macOS/Linux de sed pour le remplacement in-place
+                sed -i "s|^$var_name=.*|$var_name=$var_value|" "$TOUCH_ENV"
+            else
+                echo "$var_name=$var_value" >> "$TOUCH_ENV"
+            fi
+        fi
+    }
+
+    update_env_var "GITHUB_PAT" "$GITHUB_PAT"
+    update_env_var "HEADNODE_URL" "$HEADNODE_URL"
+
+    # 3. Exécution du setup local
+    echo "🚀 Lancement de l'installation système..."
+    cd "$INSTALL_DIR"
+    bash src/cluster/setup_runner.sh "$TARGET_REPO" "$ROLE"
+
+    echo "✅ Déploiement du $ROLE terminé avec succès dans $INSTALL_DIR."
+    exit 0
+
+else
+    # --- Client-side Installation (Research Project) ---
+    echo "🚀 Cluster-CI : Installation Client"
+
+    # 1. Vérification environnement Git
+    if [ ! -d ".git" ]; then
+        echo "❌ Erreur : Ce script doit être exécuté à la racine d'un dépôt Git."
+        exit 1
+    fi
+
+    # 2. Injection du workflow GitHub Actions
+    echo "📦 Injection du workflow GitHub Actions..."
+    mkdir -p .github/workflows
+
+    cat <<EOF > .github/workflows/cluster-ci.yml
 name: Cluster-CI Execution
 
 # =========================================================================================
@@ -59,10 +134,10 @@ jobs:
         run: /usr/local/bin/cluster-ci-run "\${{ github.repository }}" "\${{ github.head_ref || github.ref_name }}" "\${{ secrets.GITHUB_TOKEN }}"
 EOF
 
-# 3. Injection du fichier de configuration .cluster-ci
-if [ ! -f ".cluster-ci" ]; then
-    echo "📄 Création du fichier .cluster-ci..."
-    cat <<EOF > .cluster-ci
+    # 3. Injection du fichier de configuration .cluster-ci
+    if [ ! -f ".cluster-ci" ]; then
+        echo "📄 Création du fichier .cluster-ci..."
+        cat <<EOF > .cluster-ci
 # =========================================================================================
 # ⚠️ AI AGENT INSTRUCTIONS (JOULES / CURSOR) ⚠️
 # Ce fichier contrôle quelles étapes DVC sont exécutées sur le cluster distant.
@@ -77,16 +152,17 @@ if [ ! -f ".cluster-ci" ]; then
 # test_unitaires test_integration step_train
 # =========================================================================================
 EOF
-    echo "✅ Fichier .cluster-ci créé."
-else
-    echo "⚠️ Fichier .cluster-ci déjà présent, non écrasé."
-fi
+        echo "✅ Fichier .cluster-ci créé."
+    else
+        echo "⚠️ Fichier .cluster-ci déjà présent, non écrasé."
+    fi
 
-echo ""
-echo "🎉 Installation terminée !"
-echo "👉 Pensez à commiter et pusher les fichiers générés :"
-echo "   git add .github/workflows/cluster-ci.yml .cluster-ci"
-echo "   git commit -m \"docs: integration cluster-ci\""
-echo "   git push"
-echo ""
-echo "💡 Note pour l'IA Joules : Toute modification de la pipeline de recherche doit être reflétée dans .cluster-ci si vous voulez limiter l'exécution à certaines étapes."
+    echo ""
+    echo "🎉 Installation terminée !"
+    echo "👉 Pensez à commiter et pusher les fichiers générés :"
+    echo "   git add .github/workflows/cluster-ci.yml .cluster-ci"
+    echo "   git commit -m \"docs: integration cluster-ci\""
+    echo "   git push"
+    echo ""
+    echo "💡 Note pour l'IA Joules : Toute modification de la pipeline de recherche doit être reflétée dans .cluster-ci si vous voulez limiter l'exécution à certaines étapes."
+fi

--- a/src/cluster/setup_runner.sh
+++ b/src/cluster/setup_runner.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
 set -e
 
-if [ "$#" -lt 1 ]; then
-    echo "Usage: $0 <target_repo_or_org> [role]"
-    echo "Roles: headnode, worker (défaut: headnode)"
-    echo "Exemples :"
-    echo "  Headnode : $0 hjamet/cluster-ci headnode"
-    echo "  Worker   : $0 hjamet/cluster-ci worker"
+ROLE=${2:-headnode}
+TARGET=$1
+
+if [ "$ROLE" == "headnode" ] && [ -z "$TARGET" ]; then
+    echo "Usage: $0 <target_repo_or_org> headnode"
     exit 1
 fi
-
-TARGET=$1
-ROLE=${2:-headnode}
 
 # Se placer à la racine du projet
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." >/dev/null 2>&1 && pwd )"
@@ -36,16 +32,17 @@ else
     echo "✅ dvc est déjà installé."
 fi
 
-# 2. Vérification du GITHUB_PAT
-if [ ! -f ".env" ]; then
-    echo "❌ Erreur: Fichier .env manquant à la racine. Veuillez le créer avec GITHUB_PAT=..."
-    exit 1
+# 2. Chargement de l'environnement
+if [ -f ".env" ]; then
+    source .env
 fi
-source .env
 
-if [ -z "$GITHUB_PAT" ]; then
-    echo "❌ Erreur: GITHUB_PAT non défini dans le .env."
-    exit 1
+# 2.5 Vérification des pré-requis par rôle
+if [ "$ROLE" == "headnode" ]; then
+    if [ -z "$GITHUB_PAT" ]; then
+        echo "❌ Erreur: GITHUB_PAT non défini. Requis pour le rôle headnode."
+        exit 1
+    fi
 fi
 
 # 3. Préparation du dossier contenant le runner

--- a/src/scheduler/headnode_service.py
+++ b/src/scheduler/headnode_service.py
@@ -9,6 +9,24 @@ import requests
 app = Flask(__name__)
 
 FREE_SPACE_THRESHOLD_GB = 100
+CLUSTER_TOKEN = os.environ.get("CLUSTER_TOKEN")
+
+def check_token():
+    if not CLUSTER_TOKEN:
+        return True # Default to no auth if not set
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return False
+    token = auth_header.split(" ")[1]
+    return token == CLUSTER_TOKEN
+
+@app.before_request
+def require_token():
+    # Only protect API endpoints that workers or users use to modify state
+    protected_endpoints = ['register_worker', 'submit_job', 'update_job_status', 'worker_poll', 'notify_cleanup']
+    if request.endpoint in protected_endpoints:
+        if not check_token():
+            return jsonify({"error": "Unauthorized"}), 401
 
 @app.route('/register_worker', methods=['POST'])
 def register_worker():

--- a/src/scheduler/submit_job.py
+++ b/src/scheduler/submit_job.py
@@ -24,12 +24,17 @@ def submit_job(headnode_url, repo, branch):
     ram_req = get_ram_requirement()
     print(f"🚀 Submitting job for {repo}@{branch} (Required RAM: {ram_req}GB)")
 
+    token = os.environ.get("CLUSTER_TOKEN")
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
     try:
         resp = requests.post(f"{headnode_url}/submit_job", json={
             "repo": repo,
             "branch": branch,
             "ram_required_gb": ram_req
-        })
+        }, headers=headers)
         resp.raise_for_status()
         job_data = resp.json()
         job_id = job_data['job_id']

--- a/src/scheduler/worker_agent.py
+++ b/src/scheduler/worker_agent.py
@@ -15,6 +15,14 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 HEADNODE_URL = os.environ.get("HEADNODE_URL", "http://localhost:5000")
+CLUSTER_TOKEN = os.environ.get("CLUSTER_TOKEN")
+
+def get_headers():
+    headers = {}
+    if CLUSTER_TOKEN:
+        headers["Authorization"] = f"Bearer {CLUSTER_TOKEN}"
+    return headers
+
 # Generate or load a persistent worker ID
 WORKER_ID_FILE = "worker_id.txt"
 if os.path.exists(WORKER_ID_FILE):
@@ -44,7 +52,7 @@ def register():
             "service_url": SERVICE_URL,
             "total_ram_gb": total_gb,
             "available_ram_gb": available_gb
-        })
+        }, headers=get_headers())
         resp.raise_for_status()
         return True
     except Exception as e:
@@ -53,7 +61,7 @@ def register():
 
 def poll_for_job():
     try:
-        resp = requests.get(f"{HEADNODE_URL}/worker_poll/{WORKER_ID}")
+        resp = requests.get(f"{HEADNODE_URL}/worker_poll/{WORKER_ID}", headers=get_headers())
         resp.raise_for_status()
         data = resp.json()
         if data.get("job_id"):
@@ -67,7 +75,7 @@ def update_job_status(job_id, status, exit_code=None):
         payload = {"job_id": job_id, "status": status}
         if exit_code is not None:
             payload["exit_code"] = exit_code
-        resp = requests.post(f"{HEADNODE_URL}/update_job_status", json=payload)
+        resp = requests.post(f"{HEADNODE_URL}/update_job_status", json=payload, headers=get_headers())
         resp.raise_for_status()
     except Exception as e:
         logger.error(f"Failed to update job status: {e}")
@@ -161,7 +169,7 @@ def drain_pending_syncs():
         if data.get("sync_status") == "pending":
             logger.info(f"Project {project_name} has pending sync. Checking headnode space...")
             try:
-                resp = requests.get(f"{HEADNODE_URL}/check_space", timeout=5)
+                resp = requests.get(f"{HEADNODE_URL}/check_space", timeout=5, headers=get_headers())
                 resp.raise_for_status()
                 space_info = resp.json()
 


### PR DESCRIPTION
This PR introduces a unified installation experience for the Cluster CI system. 

Key changes:
1. **Universal Dispatcher (`install.sh`)**: The root installation script now detects if it's being run for a client project (default) or for infrastructure deployment (`headnode` or `worker`).
2. **One-Liner Support**: Infrastructure can now be deployed using a single `curl | bash` command, which automatically clones/updates the repository and configures the environment.
3. **Safe Environment Management**: The installation script now performs selective updates to the `.env` file, ensuring that custom variables added by the user are preserved.
4. **Improved Setup Logic**: `src/cluster/setup_runner.sh` was adjusted to make certain requirements (like `GITHUB_PAT` or target repository) conditional on the selected role.
5. **Updated Documentation**: `README.md` now features a "Déploiement du Cluster" section with clear one-liner examples.

Fixes #17

---
*PR created automatically by Jules for task [17478137923155000667](https://jules.google.com/task/17478137923155000667) started by @hjamet*