### PR TITLE
Implement E2E Integration Tests (Mock Cluster) in CI

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -1,13 +1,52 @@
-name: Test Cluster-CI Runner
+name: Test Cluster-CI E2E (Mock Cluster)
 
 on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  test_pipeline:
-    runs-on: self-hosted
+  test_e2e:
+    runs-on: ubuntu-latest
     steps:
-      - name: Trigger Orchestrator Script
-        run: /usr/local/bin/cluster-ci-run ${{ github.repository }} ${{ github.head_ref || github.ref_name }} ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Dependencies
+        run: |
+          pip install flask psutil requests
+
+      - name: Setup Mock Runner
+        run: |
+          sudo mkdir -p /usr/local/bin
+          echo -e '#!/bin/bash\necho "Mock runner executing for $1 on branch $2"\nexit 0' | sudo tee /usr/local/bin/cluster-ci-run
+          sudo chmod +x /usr/local/bin/cluster-ci-run
+
+      - name: Start Mock Cluster Services
+        run: |
+          export CLUSTER_DB_PATH=cluster_e2e.db
+          export PYTHONPATH=$PYTHONPATH:$(pwd)/src/scheduler
+          python3 src/scheduler/headnode_service.py &
+          python3 src/scheduler/scheduler_loop.py &
+          # Wait for headnode to be up
+          sleep 5
+          # Start worker agent
+          export HEADNODE_URL=http://localhost:5000
+          python3 src/scheduler/worker_agent.py &
+          sleep 5
+
+      - name: Run E2E Tests
+        run: |
+          export E2E_TEST=1
+          export HEADNODE_URL=http://localhost:5000
+          export CLUSTER_CI_RUN_PATH=/usr/local/bin/cluster-ci-run
+          export PYTHONPATH=$PYTHONPATH:$(pwd)/src/scheduler
+          python3 src/scheduler/tests/test_flow.py

--- a/src/scheduler/headnode_service.py
+++ b/src/scheduler/headnode_service.py
@@ -73,6 +73,14 @@ def submit_job():
 
     return jsonify({"job_id": job_id, "status": "pending"})
 
+@app.route('/workers', methods=['GET'])
+def list_workers():
+    with get_db_conn() as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT * FROM workers')
+        workers = [dict(row) for row in cursor.fetchall()]
+    return jsonify(workers)
+
 @app.route('/job_status/<job_id>', methods=['GET'])
 def job_status(job_id):
     with get_db_conn() as conn:

--- a/src/scheduler/tests/test_flow.py
+++ b/src/scheduler/tests/test_flow.py
@@ -16,26 +16,30 @@ from scheduler_loop import schedule_jobs
 class TestScheduler(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        os.environ["CLUSTER_DB_PATH"] = "test_cluster.db"
-        if os.path.exists("test_cluster.db"):
-            os.remove("test_cluster.db")
-        init_db()
+        cls.is_e2e = os.environ.get("E2E_TEST") == "1"
+        cls.headnode_url = os.environ.get("HEADNODE_URL", "http://localhost:5001")
 
-        # Start Headnode API in a thread
-        cls.api_thread = threading.Thread(target=lambda: app.run(port=5001, debug=False, use_reloader=False))
-        cls.api_thread.daemon = True
-        cls.api_thread.start()
+        if not cls.is_e2e:
+            os.environ["CLUSTER_DB_PATH"] = "test_cluster.db"
+            if os.path.exists("test_cluster.db"):
+                os.remove("test_cluster.db")
+            init_db()
 
-        # Start Scheduler Loop in a thread
-        cls.loop_thread = threading.Thread(target=schedule_jobs)
-        cls.loop_thread.daemon = True
-        cls.loop_thread.start()
+            # Start Headnode API in a thread
+            cls.api_thread = threading.Thread(target=lambda: app.run(port=5001, debug=False, use_reloader=False))
+            cls.api_thread.daemon = True
+            cls.api_thread.start()
 
-        # Wait for API to be ready
-        time.sleep(2)
+            # Start Scheduler Loop in a thread
+            cls.loop_thread = threading.Thread(target=schedule_jobs)
+            cls.loop_thread.daemon = True
+            cls.loop_thread.start()
+
+            # Wait for API to be ready
+            time.sleep(2)
 
     def test_full_flow(self):
-        headnode_url = "http://localhost:5001"
+        headnode_url = self.headnode_url
 
         # 1. Register a worker
         resp = requests.post(f"{headnode_url}/register_worker", json={
@@ -76,10 +80,67 @@ class TestScheduler(unittest.TestCase):
         resp = requests.get(f"{headnode_url}/job_status/{job_id}")
         self.assertEqual(resp.json()['status'], 'completed')
 
+    def test_e2e_real_worker(self):
+        if not self.is_e2e:
+            self.skipTest("Only for E2E mode")
+
+        headnode_url = self.headnode_url
+
+        # (a) Verify a worker is registered
+        print("Waiting for a worker to register...")
+        worker = None
+        for _ in range(30):
+            resp = requests.get(f"{headnode_url}/workers")
+            workers = resp.json()
+            if workers:
+                worker = workers[0]
+                break
+            time.sleep(1)
+
+        self.assertIsNotNone(worker, "No worker registered in time")
+        initial_ram = worker['available_ram_gb']
+        worker_id = worker['worker_id']
+        print(f"Worker {worker_id} found with {initial_ram}GB RAM")
+
+        # (b) Submit a job
+        ram_required = 4.0
+        print(f"Submitting job requiring {ram_required}GB RAM...")
+        resp = requests.post(f"{headnode_url}/submit_job", json={
+            "repo": "owner/repo-e2e",
+            "branch": "main",
+            "ram_required_gb": ram_required
+        })
+        self.assertEqual(resp.status_code, 200)
+        job_id = resp.json()['job_id']
+
+        # (c) Monitor job status until completed
+        print(f"Monitoring job {job_id}...")
+        final_status = None
+        for _ in range(60):
+            resp = requests.get(f"{headnode_url}/job_status/{job_id}")
+            status_data = resp.json()
+            final_status = status_data['status']
+            if final_status in ['completed', 'failed']:
+                # (d) Confirm job was assigned to a worker (Bin-Packing check)
+                self.assertIsNotNone(status_data['worker_id'], "Job was never assigned to a worker")
+                break
+            time.sleep(2)
+
+        self.assertEqual(final_status, 'completed', f"Job failed or timed out with status: {final_status}")
+        print("Job completed successfully")
+
+        # (e) Verify RAM restoration
+        resp = requests.get(f"{headnode_url}/workers")
+        workers = resp.json()
+        target_worker = next(w for w in workers if w['worker_id'] == worker_id)
+        print(f"Worker {worker_id} now has {target_worker['available_ram_gb']}GB RAM")
+        self.assertEqual(target_worker['available_ram_gb'], initial_ram, "RAM was not correctly restored")
+
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists("test_cluster.db"):
-            os.remove("test_cluster.db")
+        if not cls.is_e2e:
+            if os.path.exists("test_cluster.db"):
+                os.remove("test_cluster.db")
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/scheduler/worker_agent.py
+++ b/src/scheduler/worker_agent.py
@@ -91,7 +91,9 @@ def execute_job(job):
     update_job_status(job_id, 'running')
 
     # We call the cluster-ci-run command which is supposed to be in /usr/local/bin/cluster-ci-run
-    cmd = ["/usr/local/bin/cluster-ci-run", repo, branch]
+    # or provided via CLUSTER_CI_RUN_PATH environment variable
+    executable = os.environ.get("CLUSTER_CI_RUN_PATH", "/usr/local/bin/cluster-ci-run")
+    cmd = [executable, repo, branch]
 
     env = os.environ.copy()
     env["CLUSTER_CI_MODE"] = "executor"


### PR DESCRIPTION
This change sets up a full End-to-End (E2E) testing pipeline in the GitHub Actions CI. 

Key changes:
1. **Workflow Refactor**: `.github/workflows/test_runner.yml` now runs on `ubuntu-latest` and deploys a "Mock Cluster" by starting the headnode, scheduler loop, and worker agent as background processes on localhost.
2. **Headnode Enhancement**: Added a `/workers` endpoint to the `headnode_service.py` to allow the test suite to verify worker registration and monitor RAM state.
3. **E2E Test Suite**: Updated `src/scheduler/tests/test_flow.py` to support an `E2E_TEST` mode. Added `test_e2e_real_worker` which submits a job to the local cluster and asserts that the worker processes it, releases RAM correctly, and the job status is tracked accurately.
4. **Worker Flexibility**: Modified `worker_agent.py` to use a `CLUSTER_CI_RUN_PATH` environment variable, making it easier to mock the actual pipeline execution during tests.

These changes ensure that any PR modifying the distributed logic will be automatically validated against a real (but local) interaction between all cluster components.

Fixes #18

---
*PR created automatically by Jules for task [4670034229866764216](https://jules.google.com/task/4670034229866764216) started by @hjamet*