### PR TITLE
Propagate GitHub Actions cancellation to Workers

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.repository }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/concurrency_management.md
+++ b/docs/concurrency_management.md
@@ -1,0 +1,53 @@
+# Concurrency Management & Signal Propagation
+
+This document describes how Cluster-CI handles GitHub Actions job cancellations and ensures that compute resources on Workers are correctly freed.
+
+## Problem Statement
+
+When a new commit is pushed to a branch, GitHub Actions may cancel existing runs for that same branch if the `concurrency` key is used. GitHub sends a `SIGTERM` signal to the runner process.
+
+In a distributed architecture:
+1. The **Headnode** receives the `SIGTERM`.
+2. The **Worker** (Lenovo) is executing the actual DVC pipeline.
+
+If the Headnode simply dies, the Worker continues the computation, creating "zombie" jobs that waste RAM and CPU.
+
+## Solution: Signal Propagation
+
+We implemented a propagation mechanism to ensure the Worker is notified when a job is cancelled on the Headnode.
+
+### 1. Granular Concurrency Groups
+
+In `.github/workflows/cluster-ci.yml`, the concurrency group is set to:
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+This ensures that only jobs on the same branch/PR are cancelled, allowing multiple researchers to work on different branches simultaneously without interrupting each other.
+
+### 2. Signal Interception on Headnode
+
+The `src/scheduler/submit_job.py` script (which runs on the Headnode) intercepts `SIGINT` and `SIGTERM` signals. When a signal is received:
+- It queries the Headnode API to find the assigned Worker's `service_url`.
+- It sends a POST request to the Worker's `/cancel/<job_id>` endpoint.
+- It updates the job status to `failed` with exit code `-15` (SIGTERM).
+
+### 3. Process Tree Termination on Worker
+
+The `src/scheduler/worker_agent.py` exposes the `/cancel/<job_id>` route. When called:
+- It verifies that the `job_id` matches the currently running job.
+- It uses `psutil` to recursively kill the entire process tree of the CI job (including DVC and all sub-processes).
+- This immediately frees the reserved RAM for other jobs.
+
+## Flow Diagram
+
+```text
+GitHub Actions -> [SIGTERM] -> Headnode (submit_job.py)
+                                     |
+                                     v
+                          Worker (/cancel/<job_id>)
+                                     |
+                                     v
+                          [Kill Process Tree] -> RAM Free
+```

--- a/src/scheduler/headnode_service.py
+++ b/src/scheduler/headnode_service.py
@@ -85,7 +85,12 @@ def list_workers():
 def job_status(job_id):
     with get_db_conn() as conn:
         cursor = conn.cursor()
-        cursor.execute('SELECT * FROM jobs WHERE job_id = ?', (job_id,))
+        cursor.execute('''
+            SELECT j.*, w.service_url as worker_service_url
+            FROM jobs j
+            LEFT JOIN workers w ON j.worker_id = w.worker_id
+            WHERE j.job_id = ?
+        ''', (job_id,))
         job = cursor.fetchone()
         if job:
             return jsonify(dict(job))

--- a/src/scheduler/submit_job.py
+++ b/src/scheduler/submit_job.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 import argparse
+import signal
 
 def get_ram_requirement():
     """
@@ -46,6 +47,38 @@ def submit_job(headnode_url, repo, branch):
 
 def wait_for_job(headnode_url, job_id):
     print(f"⏳ Waiting for job {job_id} to complete...")
+
+    def signal_handler(sig, frame):
+        print(f"\n🛑 Signal received ({signal.Signals(sig).name}). Propagating cancellation...")
+        try:
+            resp = requests.get(f"{headnode_url}/job_status/{job_id}")
+            resp.raise_for_status()
+            job = resp.json()
+            worker_url = job.get('worker_service_url')
+
+            if worker_url:
+                print(f"📡 Sending cancellation to worker: {worker_url}")
+                requests.post(f"{worker_url}/cancel/{job_id}", timeout=10)
+                print("✅ Cancellation signal sent.")
+            else:
+                print("⚠️ Job was not yet assigned to a worker or worker info missing.")
+
+            # Mark job as failed/cancelled on headnode
+            token = os.environ.get("CLUSTER_TOKEN")
+            headers = {"Authorization": f"Bearer {token}"} if token else {}
+            requests.post(f"{headnode_url}/update_job_status", json={
+                "job_id": job_id,
+                "status": "failed",
+                "exit_code": -signal.SIGTERM
+            }, headers=headers)
+
+        except Exception as e:
+            print(f"⚠️ Error during cancellation: {e}")
+        sys.exit(128 + sig)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
     while True:
         try:
             resp = requests.get(f"{headnode_url}/job_status/{job_id}")
@@ -54,10 +87,10 @@ def wait_for_job(headnode_url, job_id):
             status = job['status']
 
             if status == 'completed':
-                print(f"✅ Job {job_id} completed successfully!")
+                print(f"\n✅ Job {job_id} completed successfully!")
                 return 0
             elif status == 'failed':
-                print(f"❌ Job {job_id} failed with exit code {job.get('exit_code')}")
+                print(f"\n❌ Job {job_id} failed with exit code {job.get('exit_code')}")
                 return job.get('exit_code', 1)
             elif status == 'running':
                 # Optional: could stream logs if we had a log service

--- a/src/scheduler/worker_agent.py
+++ b/src/scheduler/worker_agent.py
@@ -37,6 +37,11 @@ HOSTNAME = socket.gethostname()
 AGENT_PORT = int(os.environ.get("AGENT_PORT", 6000))
 SERVICE_URL = os.environ.get("SERVICE_URL", f"http://{HOSTNAME}:{AGENT_PORT}")
 
+# Global state for current job tracking
+current_job_id = None
+current_process = None
+job_lock = threading.Lock()
+
 def get_ram_info():
     mem = psutil.virtual_memory()
     total_gb = mem.total / (1024**3)
@@ -81,6 +86,7 @@ def update_job_status(job_id, status, exit_code=None):
         logger.error(f"Failed to update job status: {e}")
 
 def execute_job(job):
+    global current_job_id, current_process
     job_id = job['job_id']
     repo = job['repo']
     branch = job['branch']
@@ -89,6 +95,9 @@ def execute_job(job):
 
     logger.info(f"Executing job {job_id} for {repo}@{branch} with {ram_limit_gb}GB limit")
     update_job_status(job_id, 'running')
+
+    with job_lock:
+        current_job_id = job_id
 
     # We call the cluster-ci-run command which is supposed to be in /usr/local/bin/cluster-ci-run
     # or provided via CLUSTER_CI_RUN_PATH environment variable
@@ -100,6 +109,8 @@ def execute_job(job):
 
     try:
         process = subprocess.Popen(cmd, env=env)
+        with job_lock:
+            current_process = process
         oom_triggered = False
 
         # Watchdog loop
@@ -141,12 +152,20 @@ def execute_job(job):
             update_job_status(job_id, 'failed', 137)
         elif exit_code == 0:
             update_job_status(job_id, 'completed', exit_code)
+        elif exit_code < 0:
+            # Likely killed by a signal (cancellation)
+            logger.info(f"Job {job_id} was killed (exit code {exit_code})")
+            update_job_status(job_id, 'failed', exit_code)
         else:
             update_job_status(job_id, 'failed', exit_code)
 
     except Exception as e:
         logger.error(f"Execution failed: {e}")
         update_job_status(job_id, 'failed', -1)
+    finally:
+        with job_lock:
+            current_job_id = None
+            current_process = None
 
 def drain_pending_syncs():
     logger.info("Starting drain of pending synchronizations...")
@@ -199,6 +218,32 @@ def drain_pending_syncs():
 app = Flask(__name__)
 
 REPOS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "repositories")
+
+@app.route('/cancel/<job_id>', methods=['POST'])
+def cancel_job(job_id):
+    global current_job_id, current_process
+    logger.info(f"Received cancellation request for job {job_id}")
+
+    with job_lock:
+        if current_job_id == job_id and current_process:
+            logger.info(f"Killing process tree for job {job_id}")
+            try:
+                parent = psutil.Process(current_process.pid)
+                for child in parent.children(recursive=True):
+                    try:
+                        child.kill()
+                    except psutil.NoSuchProcess:
+                        pass
+                parent.kill()
+                return jsonify({"status": "cancelled", "message": "Process tree terminated"}), 200
+            except psutil.NoSuchProcess:
+                return jsonify({"status": "already_finished", "message": "Process already finished"}), 200
+            except Exception as e:
+                logger.error(f"Error while killing process: {e}")
+                return jsonify({"status": "error", "message": str(e)}), 500
+        else:
+            logger.warning(f"No active job matches {job_id} (current: {current_job_id})")
+            return jsonify({"status": "not_found", "message": "Job not running on this worker"}), 404
 
 @app.route('/fetch_artifact/<path:file_path>', methods=['GET'])
 def fetch_artifact(file_path):


### PR DESCRIPTION
This change ensures that when a GitHub Action job is cancelled, the cancellation signal (SIGTERM) is propagated from the Headnode to the assigned Worker node. 

Key changes:
1. **Worker Agent**: Added a `/cancel/<job_id>` POST endpoint that uses `psutil` to recursively kill the process tree of a running job.
2. **Headnode Service**: Updated the `/job_status` endpoint to include the `service_url` of the worker assigned to the job.
3. **Submit Job Script**: Implemented signal handlers for `SIGINT` and `SIGTERM` to intercept GitHub Actions cancellations, retrieve the worker URL, and trigger the remote cancellation.
4. **Workflow Configuration**: Modified the concurrency group in `.github/workflows/cluster-ci.yml` to `${{ github.workflow }}-${{ github.ref }}` to prevent cross-branch job cancellations.
5. **Documentation**: Added `docs/concurrency_management.md` explaining the propagation flow.

Fixes #22

---
*PR created automatically by Jules for task [18143466512591376110](https://jules.google.com/task/18143466512591376110) started by @hjamet*