### PR TITLE
Headnode Portal (OAuth & Reverse Proxy)

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install flask psutil requests
+          pip install flask psutil requests authlib
 
       - name: Setup Mock Runner
         run: |

--- a/src/scheduler/headnode_service.py
+++ b/src/scheduler/headnode_service.py
@@ -1,12 +1,32 @@
-from flask import Flask, request, jsonify, send_from_directory, Response, stream_with_context
+from flask import Flask, request, jsonify, send_from_directory, Response, stream_with_context, session, url_for, redirect, render_template
 from persistence import init_db, get_db_conn
+from authlib.integrations.flask_client import OAuth
 import uuid
 import datetime
 import os
 import shutil
 import requests
+import subprocess
+import time
+import threading
+import socket
+from urllib.parse import urlparse
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", os.urandom(24))
+
+oauth = OAuth(app)
+oauth.register(
+    name='github',
+    client_id=os.environ.get('GITHUB_CLIENT_ID'),
+    client_secret=os.environ.get('GITHUB_CLIENT_SECRET'),
+    access_token_url='https://github.com/login/oauth/access_token',
+    access_token_params=None,
+    authorize_url='https://github.com/login/oauth/authorize',
+    authorize_params=None,
+    api_base_url='https://api.github.com/',
+    client_kwargs={'scope': 'repo,user:email'},
+)
 
 FREE_SPACE_THRESHOLD_GB = 100
 CLUSTER_TOKEN = os.environ.get("CLUSTER_TOKEN")
@@ -224,6 +244,182 @@ def notify_cleanup():
 
     return jsonify({"status": "ok", "notified": notified, "errors": errors})
 
+# --- Portal & OAuth Routes ---
+
+@app.route('/')
+def dashboard():
+    if 'user' not in session:
+        return render_template('login.html')
+
+    token = session.get('token')
+    # Fetch user repos from GitHub API
+    try:
+        repos_resp = oauth.github.get('user/repos', token=token)
+        repos = repos_resp.json()
+        if not isinstance(repos, list):
+            repos = []
+    except Exception as e:
+        print(f"Error fetching repos: {e}")
+        repos = []
+
+    return render_template('dashboard.html', user=session['user'], repos=repos)
+
+@app.route('/login')
+def login():
+    redirect_uri = url_for('authorize', _external=True)
+    return oauth.github.authorize_redirect(redirect_uri)
+
+@app.route('/authorize')
+def authorize():
+    token = oauth.github.authorize_access_token()
+    resp = oauth.github.get('user', token=token)
+    user = resp.json()
+    session['user'] = user
+    session['token'] = token
+    return redirect(url_for('dashboard'))
+
+@app.route('/logout')
+def logout():
+    session.pop('user', None)
+    session.pop('token', None)
+    return redirect(url_for('dashboard'))
+
+# --- Proxy & DVC-Viewer Management ---
+
+DVC_VIEWER_PORT = int(os.environ.get("DVC_VIEWER_PORT", 8686))
+DVC_VIEWER_TIMEOUT_MIN = int(os.environ.get("DVC_VIEWER_TIMEOUT_MIN", 30))
+
+# Registry for local dvc-viewer processes
+# { repo_full_name: { 'proc': subprocess.Popen, 'port': int, 'last_access': float } }
+local_viewers = {}
+local_viewers_lock = threading.Lock()
+
+def get_free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+def cleanup_inactive_viewers():
+    """Background task to kill local dvc-viewer processes after inactivity."""
+    while True:
+        time.sleep(60)
+        now = time.time()
+        to_delete = []
+        with local_viewers_lock:
+            for repo_name, viewer in local_viewers.items():
+                if now - viewer['last_access'] > (DVC_VIEWER_TIMEOUT_MIN * 60):
+                    print(f"Terminating inactive dvc-viewer for {repo_name} (port {viewer['port']})")
+                    try:
+                        viewer['proc'].terminate()
+                        viewer['proc'].wait(timeout=5)
+                    except Exception as e:
+                        print(f"Error terminating process: {e}")
+                        try:
+                            viewer['proc'].kill()
+                        except:
+                            pass
+                    to_delete.append(repo_name)
+
+            for repo_name in to_delete:
+                del local_viewers[repo_name]
+
+@app.route('/view/<owner>/<repo>/')
+@app.route('/view/<owner>/<repo>/<path:path>')
+def view_project(owner, repo, path=''):
+    if 'user' not in session:
+        return redirect(url_for('dashboard'))
+
+    repo_full_name = f"{owner}/{repo}"
+
+    # --- Case 1: Live (Running on a worker) ---
+    with get_db_conn() as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT w.service_url
+            FROM jobs j
+            JOIN workers w ON j.worker_id = w.worker_id
+            WHERE j.repo = ? AND j.status = 'running'
+            ORDER BY j.started_at DESC LIMIT 1
+        ''', (repo_full_name,))
+        job = cursor.fetchone()
+
+    if job and job['service_url']:
+        worker_base_url = job['service_url']
+        # Extract hostname/IP from service_url (e.g., http://worker1:6000 -> worker1)
+        parsed = urlparse(worker_base_url)
+        target_host = parsed.hostname
+        target_url = f"http://{target_host}:{DVC_VIEWER_PORT}/{path}"
+        return proxy_request(target_url)
+
+    # --- Case 2: Historical (Local) ---
+    repo_path = os.path.join(REPOS_DIR, owner, repo)
+    if not os.path.exists(repo_path):
+        return f"Projet {repo_full_name} non trouvé localement et non actif.", 404
+
+    with local_viewers_lock:
+        if repo_full_name in local_viewers:
+            viewer = local_viewers[repo_full_name]
+            # Check if process is still alive
+            if viewer['proc'].poll() is None:
+                viewer['last_access'] = time.time()
+                target_url = f"http://localhost:{viewer['port']}/{path}"
+                return proxy_request(target_url)
+            else:
+                del local_viewers[repo_full_name]
+
+        # Start a new dvc-viewer process
+        port = get_free_port()
+        try:
+            # We assume dvc-viewer is available in the environment
+            # and it supports a --port argument.
+            # Using 'uv run' if possible or direct call
+            cmd = ["uv", "run", "dvc-viewer", "serve", "--port", str(port)]
+            # If dvc-viewer is not a uv project, might need just ["dvc-viewer", "serve", ...]
+            # Given the context of the project, it's likely uv-managed or installed as a tool.
+            proc = subprocess.Popen(cmd, cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            # Wait a bit for the server to start
+            time.sleep(2)
+
+            local_viewers[repo_full_name] = {
+                'proc': proc,
+                'port': port,
+                'last_access': time.time()
+            }
+            target_url = f"http://localhost:{port}/{path}"
+            return proxy_request(target_url)
+        except Exception as e:
+            return f"Failed to start dvc-viewer: {str(e)}", 500
+
+def proxy_request(target_url):
+    """Simple proxy that forwards the request to the target_url."""
+    try:
+        resp = requests.request(
+            method=request.method,
+            url=target_url,
+            headers={key: value for (key, value) in request.headers if key != 'Host'},
+            data=request.get_data(),
+            cookies=request.cookies,
+            allow_redirects=False,
+            params=request.args,
+            stream=True
+        )
+
+        excluded_headers = ['content-encoding', 'content-length', 'transfer-encoding', 'connection']
+        headers = [(name, value) for (name, value) in resp.raw.headers.items()
+                   if name.lower() not in excluded_headers]
+
+        response = Response(stream_with_context(resp.iter_content(chunk_size=1024)),
+                            status=resp.status_code,
+                            headers=headers)
+        return response
+    except Exception as e:
+        return f"Proxy Error: {str(e)}", 502
+
 if __name__ == '__main__':
     init_db()
+    # Start cleanup thread
+    threading.Thread(target=cleanup_inactive_viewers, daemon=True).start()
     app.run(host='0.0.0.0', port=5000)

--- a/src/scheduler/templates/dashboard.html
+++ b/src/scheduler/templates/dashboard.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cluster-CI Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="#">Cluster-CI</a>
+            <div class="navbar-text text-light">
+                Connecté en tant que <strong>{{ user.login }}</strong>
+                <a href="{{ url_for('logout') }}" class="btn btn-outline-light btn-sm ms-3">Déconnexion</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container mt-4">
+        <h2>Vos Projets</h2>
+        <div class="row">
+            {% for repo in repos %}
+            <div class="col-md-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">{{ repo.full_name }}</h5>
+                        <p class="card-text text-muted">{{ repo.description or 'Aucune description' }}</p>
+                    </div>
+                    <div class="card-footer bg-white border-top-0">
+                        <a href="{{ url_for('view_project', owner=repo.owner.login, repo=repo.name) }}" class="btn btn-primary w-100">Consulter les résultats (DVC Viewer)</a>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+            {% if not repos %}
+            <div class="col-12">
+                <div class="alert alert-info">Aucun projet trouvé sur GitHub.</div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</body>
+</html>

--- a/src/scheduler/templates/login.html
+++ b/src/scheduler/templates/login.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cluster-CI Login</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="bg-light">
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card shadow">
+                    <div class="card-body text-center">
+                        <h1 class="card-title mb-4">Cluster-CI Portal</h1>
+                        <p class="card-text">Veuillez vous connecter avec votre compte GitHub pour accéder à vos projets.</p>
+                        <a href="{{ url_for('login') }}" class="btn btn-dark btn-lg">
+                            <i class="bi bi-github"></i> Se connecter avec GitHub
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/scheduler/tests/test_portal.py
+++ b/src/scheduler/tests/test_portal.py
@@ -1,0 +1,120 @@
+import unittest
+import os
+import time
+import subprocess
+import requests
+import threading
+from unittest.mock import patch, MagicMock
+# Import app AFTER setting env vars
+os.environ['GITHUB_CLIENT_ID'] = 'fake_id'
+os.environ['GITHUB_CLIENT_SECRET'] = 'fake_secret'
+os.environ['CLUSTER_DB_PATH'] = 'test_cluster_scheduler.db'
+os.environ['DVC_VIEWER_TIMEOUT_MIN'] = '0' # Force immediate timeout for testing cleanup
+from src.scheduler.headnode_service import app, local_viewers, local_viewers_lock, cleanup_inactive_viewers
+from src.scheduler.persistence import init_db, get_db_conn
+
+class TestPortalAndProxy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        init_db()
+        # Ensure session is used
+        app.config['TESTING'] = True
+        app.config['SECRET_KEY'] = 'test'
+        cls.client = app.test_client()
+        cls.app_context = app.app_context()
+        cls.app_context.push()
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists('test_cluster_scheduler.db'):
+            os.remove('test_cluster_scheduler.db')
+        cls.app_context.pop()
+
+    def setUp(self):
+        with local_viewers_lock:
+            local_viewers.clear()
+
+    def test_dashboard_renders_login_template(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Cluster-CI Portal', response.data)
+
+    def test_view_project_redirects_when_not_logged_in(self):
+        # Let's try to fetch what exactly is in the url_map for view_project
+        with app.test_request_context():
+            from flask import url_for
+            target = url_for('view_project', owner='someowner', repo='somerepo')
+
+        response = self.client.get(target, follow_redirects=False)
+        self.assertEqual(response.status_code, 302, f"Failed for {target}. Body: {response.data}")
+        self.assertTrue(response.location.endswith('/'))
+
+    def test_view_project_404_when_repo_missing(self):
+        with self.client.session_transaction() as sess:
+            sess['user'] = {'login': 'testuser'}
+
+        with app.test_request_context():
+            from flask import url_for
+            target = url_for('view_project', owner='nonexistent', repo='repo')
+
+        response = self.client.get(target, follow_redirects=True)
+        self.assertEqual(response.status_code, 404)
+        # Check for presence of key words as strings from the decoded response
+        body = response.data.decode('utf-8')
+        self.assertIn('non', body)
+        self.assertIn('trouv', body)
+        self.assertIn('localement', body)
+
+    def test_historical_proxy_spawns_process(self):
+        # Mock login
+        with self.client.session_transaction() as sess:
+            sess['user'] = {'login': 'testuser'}
+            sess['token'] = {'access_token': 'fake_token'}
+
+        # Create a dummy repo directory
+        os.makedirs('repositories/testowner/testrepo', exist_ok=True)
+
+        with patch('subprocess.Popen') as mock_popen:
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_popen.return_value = mock_proc
+
+            with patch('src.scheduler.headnode_service.proxy_request') as mock_proxy:
+                mock_proxy.return_value = app.response_class("proxied")
+                response = self.client.get('/view/testowner/testrepo/')
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.data, b'proxied')
+                mock_popen.assert_called()
+                with local_viewers_lock:
+                    self.assertIn('testowner/testrepo', local_viewers)
+
+        # Clean up dummy repo
+        import shutil
+        shutil.rmtree('repositories/testowner')
+
+    def test_inactivity_cleanup(self):
+        # Manually add a fake viewer to the registry
+        mock_proc = MagicMock()
+        with local_viewers_lock:
+            local_viewers['old/repo'] = {
+                'proc': mock_proc,
+                'port': 12345,
+                'last_access': time.time() - 10 # 10 seconds ago, and timeout is 0
+            }
+
+        from src.scheduler.headnode_service import cleanup_inactive_viewers
+
+        with patch('time.sleep', side_effect=[None, Exception("Stop loop")]):
+            try:
+                cleanup_inactive_viewers()
+            except Exception as e:
+                if str(e) != "Stop loop":
+                    raise e
+
+        with local_viewers_lock:
+            self.assertNotIn('old/repo', local_viewers)
+        mock_proc.terminate.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a central portal on the Headnode, allowing researchers to securely authenticate via GitHub and access dvc-viewer interfaces for their projects.

Key features:
1. **GitHub OAuth**: Researchers log in with GitHub to see their accessible repositories.
2. **Dynamic Reverse Proxy**: A unified entry point (/view/owner/repo) that automatically routes traffic:
   - To the active worker node if the project is currently running.
   - To a locally spawned `dvc-viewer` instance on the headnode if the project is idle but present in the local cache.
3. **Automatic Cleanup**: Local `dvc-viewer` instances are automatically terminated after a configurable period of inactivity (default 30 minutes) to save resources.
4. **Dashboard**: A simple UI to navigate through projects.

Dependencies added: `authlib`, `requests`.

Fixes #25

---
*PR created automatically by Jules for task [5644658619871153313](https://jules.google.com/task/5644658619871153313) started by @hjamet*