### PR TITLE
Add DVC history exploration APIs to Headnode

### DIFF
--- a/src/scheduler/headnode_service.py
+++ b/src/scheduler/headnode_service.py
@@ -245,6 +245,65 @@ def notify_cleanup():
 
     return jsonify({"status": "ok", "notified": notified, "errors": errors})
 
+# --- History & DVC Exploration APIs ---
+
+@app.route('/api/projects', methods=['GET'])
+def api_list_projects():
+    with get_db_conn() as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT DISTINCT repo FROM jobs')
+        projects = [row['repo'] for row in cursor.fetchall()]
+    return jsonify(projects)
+
+@app.route('/api/projects/<path:repo>/runs', methods=['GET'])
+def api_list_runs(repo):
+    with get_db_conn() as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT job_id, branch, status, commit_hash, created_at, started_at, finished_at, exit_code
+            FROM jobs
+            WHERE repo = ?
+            ORDER BY created_at DESC
+        ''', (repo,))
+        runs = [dict(row) for row in cursor.fetchall()]
+    return jsonify(runs)
+
+@app.route('/api/runs/<job_id>/files', methods=['GET'])
+def api_run_files(job_id):
+    with get_db_conn() as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT repo, commit_hash FROM jobs WHERE job_id = ?', (job_id,))
+        job = cursor.fetchone()
+
+    if not job:
+        return jsonify({"error": "Job not found"}), 404
+
+    repo = job['repo']
+    commit_hash = job['commit_hash']
+
+    if not commit_hash:
+        return jsonify({"error": "Commit hash not found for this job. Historical exploration is unavailable."}), 400
+
+    repo_url = f"https://github.com/{repo}"
+
+    try:
+        env = os.environ.copy()
+        # If GITHUB_PAT is available, dvc list might be able to use it if configured,
+        # though dvc list usually uses git credentials.
+
+        cmd = ["dvc", "list", repo_url, "--rev", commit_hash, "--json"]
+        result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+        if result.returncode != 0:
+            return jsonify({
+                "error": "Failed to list DVC files",
+                "details": result.stderr
+            }), 500
+
+        return Response(result.stdout, mimetype='application/json')
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
 # --- Portal & OAuth Routes ---
 
 @app.route('/')

--- a/src/scheduler/tests/test_history_api.py
+++ b/src/scheduler/tests/test_history_api.py
@@ -1,0 +1,95 @@
+import pytest
+import os
+import json
+import sqlite3
+from unittest.mock import patch, MagicMock
+
+# Set the DB path before importing anything that might use it
+test_db = "test_history.db"
+if os.path.exists(test_db):
+    os.remove(test_db)
+os.environ["CLUSTER_DB_PATH"] = test_db
+
+from headnode_service import app, init_db
+from persistence import DB_PATH
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        with app.app_context():
+            init_db()
+            yield client
+
+    if os.path.exists(test_db):
+        os.remove(test_db)
+
+def test_history_apis(client):
+    # 1. Inject some data
+    conn = sqlite3.connect(test_db)
+    cursor = conn.cursor()
+    cursor.execute('''
+        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+    ''', ("job1", "owner/repo1", "main", "hash1", "completed", "2023-01-01 10:00:00"))
+    cursor.execute('''
+        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+    ''', ("job2", "owner/repo1", "feat", "hash2", "completed", "2023-01-01 11:00:00"))
+    cursor.execute('''
+        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+    ''', ("job3", "owner/repo2", "main", "hash3", "completed", "2023-01-01 12:00:00"))
+    conn.commit()
+    conn.close()
+
+    # 2. Test /api/projects
+    resp = client.get('/api/projects')
+    assert resp.status_code == 200
+    projects = resp.get_json()
+    assert "owner/repo1" in projects
+    assert "owner/repo2" in projects
+    assert len(projects) == 2
+
+    # 3. Test /api/projects/<repo>/runs
+    resp = client.get('/api/projects/owner/repo1/runs')
+    assert resp.status_code == 200
+    runs = resp.get_json()
+    assert len(runs) == 2
+    assert runs[0]['job_id'] == "job2" # Ordered by created_at DESC
+    assert runs[1]['job_id'] == "job1"
+
+    # 4. Test /api/runs/<job_id>/files (with Mocking subprocess)
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([{"path": "data.csv", "isout": True}])
+        )
+
+        resp = client.get('/api/runs/job1/files')
+        assert resp.status_code == 200
+        files = resp.get_json()
+        assert len(files) == 1
+        assert files[0]['path'] == "data.csv"
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert "dvc" in args
+        assert "list" in args
+        assert "https://github.com/owner/repo1" in args
+        assert "--rev" in args
+        assert "hash1" in args
+
+    # 5. Test Error cases
+    resp = client.get('/api/runs/nonexistent/files')
+    assert resp.status_code == 404
+
+    # Test job without commit_hash
+    conn = sqlite3.connect(test_db)
+    cursor = conn.cursor()
+    cursor.execute('INSERT INTO jobs (job_id, repo, branch, status) VALUES (?, ?, ?, ?)', ("job_no_hash", "owner/repo1", "main", "completed"))
+    conn.commit()
+    conn.close()
+
+    resp = client.get('/api/runs/job_no_hash/files')
+    assert resp.status_code == 400
+    assert "Commit hash not found" in resp.get_json()['error']


### PR DESCRIPTION
This PR implements the requested history exploration APIs on the Headnode.
These endpoints allow the frontend to:
1. List all projects that have executed at least one job.
2. List all runs (jobs) for a specific project, ordered by date.
3. Explore the file tree of a specific run by querying DVC remotely using the stored commit hash.

The implementation uses the existing database schema and integrates with the `dvc list` command for remote exploration. Proper error handling for missing jobs or commit hashes is included.
A new test suite `src/scheduler/tests/test_history_api.py` verifies the functionality.

Fixes #36

---
*PR created automatically by Jules for task [7646597294129905864](https://jules.google.com/task/7646597294129905864) started by @hjamet*