### PR TITLE
Dynamic Port Allocation for dvc-viewer

### DIFF
--- a/src/runner/run_research_pipeline.sh
+++ b/src/runner/run_research_pipeline.sh
@@ -185,8 +185,13 @@ fi
 log_info "Analyse AST via dvc-viewer..."
 uv run dvc-viewer hash
 
-log_info "Lancement du serveur live dvc-viewer..."
-uv run dvc-viewer --port 8686 > "$BASE_DIR/dvc-viewer.log" 2>&1 &
+log_info "Recherche d'un port libre pour dvc-viewer..."
+VIEWER_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+log_info "Port sélectionné : $VIEWER_PORT"
+echo "$VIEWER_PORT" > .cluster-ci-viewer-port
+
+log_info "Lancement du serveur live dvc-viewer sur le port $VIEWER_PORT..."
+uv run dvc-viewer --port "$VIEWER_PORT" > "$BASE_DIR/dvc-viewer.log" 2>&1 &
 DVC_VIEWER_PID=$!
 
 log_info "Lancement de : uv run dvc repro $DVC_ARGS"

--- a/src/scheduler/headnode_service.py
+++ b/src/scheduler/headnode_service.py
@@ -140,11 +140,19 @@ def update_job_status():
     status = data.get('status')
     exit_code = data.get('exit_code')
     commit_hash = data.get('commit_hash')
+    viewer_port = data.get('viewer_port')
 
     with get_db_conn() as conn:
         cursor = conn.cursor()
         if status == 'running':
-            cursor.execute('UPDATE jobs SET status = ?, started_at = CURRENT_TIMESTAMP, commit_hash = ? WHERE job_id = ?', (status, commit_hash, job_id))
+            cursor.execute('''
+                UPDATE jobs SET
+                    status = ?,
+                    started_at = COALESCE(started_at, CURRENT_TIMESTAMP),
+                    commit_hash = COALESCE(?, commit_hash),
+                    viewer_port = COALESCE(?, viewer_port)
+                WHERE job_id = ?
+            ''', (status, commit_hash, viewer_port, job_id))
         elif status in ['completed', 'failed']:
             # Restore RAM to the worker
             cursor.execute('SELECT worker_id, ram_required_gb FROM jobs WHERE job_id = ?', (job_id,))
@@ -429,7 +437,7 @@ def view_project(owner, repo, path=''):
     with get_db_conn() as conn:
         cursor = conn.cursor()
         cursor.execute('''
-            SELECT w.service_url
+            SELECT w.service_url, j.viewer_port
             FROM jobs j
             JOIN workers w ON j.worker_id = w.worker_id
             WHERE j.repo = ? AND j.status = 'running'
@@ -439,10 +447,12 @@ def view_project(owner, repo, path=''):
 
     if job and job['service_url']:
         worker_base_url = job['service_url']
+        # Use dynamic port if available, otherwise fallback to default
+        viewer_port = job.get('viewer_port') or DVC_VIEWER_PORT
         # Extract hostname/IP from service_url (e.g., http://worker1:6000 -> worker1)
         parsed = urlparse(worker_base_url)
         target_host = parsed.hostname
-        target_url = f"http://{target_host}:{DVC_VIEWER_PORT}/{path}"
+        target_url = f"http://{target_host}:{viewer_port}/{path}"
         return proxy_request(target_url)
 
     # --- Case 2: Historical (Local) ---

--- a/src/scheduler/persistence.py
+++ b/src/scheduler/persistence.py
@@ -41,6 +41,7 @@ def init_db():
             started_at TIMESTAMP,
             finished_at TIMESTAMP,
             exit_code INTEGER,
+            viewer_port INTEGER,
             FOREIGN KEY (worker_id) REFERENCES workers (worker_id)
         )
     ''')
@@ -48,6 +49,12 @@ def init_db():
     # Migration for commit_hash
     try:
         cursor.execute('ALTER TABLE jobs ADD COLUMN commit_hash TEXT')
+    except sqlite3.OperationalError:
+        pass # Already exists
+
+    # Migration for viewer_port
+    try:
+        cursor.execute('ALTER TABLE jobs ADD COLUMN viewer_port INTEGER')
     except sqlite3.OperationalError:
         pass # Already exists
 

--- a/src/scheduler/tests/test_history_api.py
+++ b/src/scheduler/tests/test_history_api.py
@@ -28,17 +28,17 @@ def test_history_apis(client):
     conn = sqlite3.connect(test_db)
     cursor = conn.cursor()
     cursor.execute('''
-        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at)
-        VALUES (?, ?, ?, ?, ?, ?)
-    ''', ("job1", "owner/repo1", "main", "hash1", "completed", "2023-01-01 10:00:00"))
+        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at, ram_required_gb)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    ''', ("job1", "owner/repo1", "main", "hash1", "completed", "2023-01-01 10:00:00", 0))
     cursor.execute('''
-        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at)
-        VALUES (?, ?, ?, ?, ?, ?)
-    ''', ("job2", "owner/repo1", "feat", "hash2", "completed", "2023-01-01 11:00:00"))
+        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at, ram_required_gb)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    ''', ("job2", "owner/repo1", "feat", "hash2", "completed", "2023-01-01 11:00:00", 0))
     cursor.execute('''
-        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at)
-        VALUES (?, ?, ?, ?, ?, ?)
-    ''', ("job3", "owner/repo2", "main", "hash3", "completed", "2023-01-01 12:00:00"))
+        INSERT INTO jobs (job_id, repo, branch, commit_hash, status, created_at, ram_required_gb)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    ''', ("job3", "owner/repo2", "main", "hash3", "completed", "2023-01-01 12:00:00", 0))
     conn.commit()
     conn.close()
 
@@ -86,7 +86,7 @@ def test_history_apis(client):
     # Test job without commit_hash
     conn = sqlite3.connect(test_db)
     cursor = conn.cursor()
-    cursor.execute('INSERT INTO jobs (job_id, repo, branch, status) VALUES (?, ?, ?, ?)', ("job_no_hash", "owner/repo1", "main", "completed"))
+    cursor.execute('INSERT INTO jobs (job_id, repo, branch, status, ram_required_gb) VALUES (?, ?, ?, ?, ?)', ("job_no_hash", "owner/repo1", "main", "completed", 0))
     conn.commit()
     conn.close()
 

--- a/src/scheduler/worker_agent.py
+++ b/src/scheduler/worker_agent.py
@@ -75,13 +75,15 @@ def poll_for_job():
         logger.error(f"Failed to poll: {e}")
     return None
 
-def update_job_status(job_id, status, exit_code=None, commit_hash=None):
+def update_job_status(job_id, status, exit_code=None, commit_hash=None, viewer_port=None):
     try:
         payload = {"job_id": job_id, "status": status}
         if exit_code is not None:
             payload["exit_code"] = exit_code
         if commit_hash is not None:
             payload["commit_hash"] = commit_hash
+        if viewer_port is not None:
+            payload["viewer_port"] = viewer_port
         resp = requests.post(f"{HEADNODE_URL}/update_job_status", json=payload, headers=get_headers())
         resp.raise_for_status()
     except Exception as e:
@@ -114,9 +116,23 @@ def execute_job(job):
         with job_lock:
             current_process = process
         oom_triggered = False
+        port_reported = False
 
         # Watchdog loop
         while process.poll() is None:
+            # Try to report dynamic viewer port if not already done
+            if not port_reported:
+                port_file = os.path.join(REPOS_DIR, repo, ".cluster-ci-viewer-port")
+                if os.path.exists(port_file):
+                    try:
+                        with open(port_file, 'r') as f:
+                            viewer_port = int(f.read().strip())
+                        logger.info(f"Reporting dynamic viewer port {viewer_port} for job {job_id}")
+                        update_job_status(job_id, 'running', viewer_port=viewer_port)
+                        port_reported = True
+                    except Exception as e:
+                        logger.error(f"Failed to read/report viewer port: {e}")
+
             try:
                 parent = psutil.Process(process.pid)
                 # RSS of parent

--- a/worker_id.txt
+++ b/worker_id.txt
@@ -1,0 +1,1 @@
+90092f9b-befe-40ed-8dfc-01bb258d4e5c


### PR DESCRIPTION
This PR introduces dynamic port assignment for the `dvc-viewer` server on worker nodes. This prevents port collisions (previously hardcoded to 8686) when multiple jobs are running concurrently on the same worker.

Key changes:
- `src/runner/run_research_pipeline.sh`: Now finds a free port and saves it to `.cluster-ci-viewer-port`.
- `src/scheduler/persistence.py`: Added `viewer_port` column to the `jobs` table.
- `src/scheduler/worker_agent.py`: Monitors the viewer port file and reports it to the headnode.
- `src/scheduler/headnode_service.py`: Stores the dynamic port and uses it in the `/view` proxy logic. Improved `update_job_status` to safely handle partial updates using `COALESCE`.
- `src/scheduler/tests/test_history_api.py`: Updated to accommodate schema changes.

Fixes #29

---
*PR created automatically by Jules for task [12157149331948977945](https://jules.google.com/task/12157149331948977945) started by @hjamet*