### PR TITLE
fix: enhance auto-update resilience and strictly segregate CI runners

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   execute-on-cluster:
     name: Execute Research Pipeline
-    runs-on: self-hosted
+    runs-on: [self-hosted, cluster-worker]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/install.sh
+++ b/install.sh
@@ -212,7 +212,7 @@ concurrency:
 jobs:
   execute-on-cluster:
     name: Execute Research Pipeline
-    runs-on: self-hosted
+    runs-on: [self-hosted, cluster-worker]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/src/cluster/setup_runner.sh
+++ b/src/cluster/setup_runner.sh
@@ -116,6 +116,15 @@ if [ ! -d "$ADMIN_SLOT_DIR" ]; then
     cp -r "$TEMPLATE_DIR" "$ADMIN_SLOT_DIR"
 fi
 
+# 4.5. Sudoers Configuration for Auto-Update
+echo "🔐 Configuring sudoers for cluster-ci CI privileges..."
+cat <<EOF | sudo tee /etc/sudoers.d/cluster-ci > /dev/null
+Defaults:$USER !requiretty
+$USER ALL=(ALL) NOPASSWD: /bin/systemctl restart cluster-*, /usr/bin/systemctl restart cluster-*
+EOF
+sudo chmod 0440 /etc/sudoers.d/cluster-ci
+echo "✅ Sudoers configured."
+
 # 5. Systemd Installation
 if [ "$ROLE" == "headnode" ]; then
     echo "⚙️ Installing systemd service for Ephemeral Runner Manager..."

--- a/src/scheduler/runner_manager.py
+++ b/src/scheduler/runner_manager.py
@@ -5,6 +5,7 @@ import requests
 import logging
 import threading
 import sys
+import shutil
 from pathlib import Path
 from dotenv import load_dotenv
 
@@ -52,6 +53,14 @@ class RunnerManager:
             slot_dir = self.runners_dir / f"slot{slot_id}"
         logger = logging.LoggerAdapter(logging.getLogger(__name__), {'slot': slot_id})
 
+        # Auto-Healing: Provision slot_dir if missing
+        template_dir = self.runners_dir / "template"
+        if not slot_dir.exists():
+            logger.info(f"Slot directory {slot_dir} is missing. Provisioning from template...")
+            if not template_dir.exists():
+                raise FileNotFoundError(f"Template directory {template_dir} is missing. Cannot provision slot {slot_id}.")
+            shutil.copytree(template_dir, slot_dir)
+
         while True:
             try:
                 logger.info(f"Preparing a new ephemeral runner (labels: {labels})...")
@@ -83,15 +92,18 @@ class RunnerManager:
 
                 logger.info(f"Runner stopped with code {process.returncode}. Imminent restart...")
 
+            except (subprocess.CalledProcessError, requests.RequestException) as e:
+                logger.error(f"Transient error in runner cycle: {e}. Retrying in 10s...")
+                time.sleep(10)
             except Exception as e:
-                logger.error(f"Error in runner cycle: {e}")
-                time.sleep(10) # Wait a bit before retrying in case of fatal error
+                logger.critical(f"Fatal error in runner cycle: {e}")
+                raise  # Fail-fast instead of looping on a fatal error
 
     def start(self):
         threads = []
         # Standard slots
         for i in range(1, self.num_slots + 1):
-            t = threading.Thread(target=self.run_slot, args=(i,))
+            t = threading.Thread(target=self.run_slot, args=(i, "self-hosted,cluster-worker"))
             t.daemon = True
             t.start()
             threads.append(t)


### PR DESCRIPTION
Implemented systemic fixes for the GitOps auto-update process and environment segregation.

Key changes:
- `runner_manager.py`: Implemented dynamic template provisioning for missing slots and refactored the exception loop to allow fail-fast behavior on fatal errors. Explicitly added `self-hosted,cluster-worker` labels to standard slots.
- `setup_runner.sh`: Securely configured passwordless `systemctl restart cluster-*` sudo privileges for the GitOps user.
- CI Templates: Updated `.github/workflows/cluster-ci.yml` and `install.sh` to specifically request `[self-hosted, cluster-worker]` runners.

---
*PR created automatically by Jules for task [15120972830170958204](https://jules.google.com/task/15120972830170958204) started by @hjamet*