### PR TITLE
fix: Resolve race condition during worker startup causing -98 exit codes

### DIFF
--- a/ci.log
+++ b/ci.log
@@ -1,99 +1,160 @@
-2026-05-20T13:37:25.4139622Z  * Serving Flask app 'worker_agent'
-2026-05-20T13:37:25.4140072Z  * Debug mode: off
-2026-05-20T13:37:25.4157362Z INFO:werkzeug:[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
-2026-05-20T13:37:25.4173440Z  * Running on all addresses (0.0.0.0)
-2026-05-20T13:37:25.4173754Z  * Running on http://127.0.0.1:6000
-2026-05-20T13:37:25.4174024Z  * Running on http://10.1.0.207:6000
-2026-05-20T13:37:25.4174773Z INFO:werkzeug:[33mPress CTRL+C to quit[0m
-2026-05-20T13:37:25.4194427Z 127.0.0.1 - - [20/May/2026 13:37:25] "POST /register_worker HTTP/1.1" 200 -
-2026-05-20T13:37:25.4224412Z 127.0.0.1 - - [20/May/2026 13:37:25] "GET /worker_poll/ea49502f-6a5b-4502-8a42-2add9dd3d502 HTTP/1.1" 200 -
-2026-05-20T13:37:30.4311142Z 127.0.0.1 - - [20/May/2026 13:37:30] "GET /worker_poll/ea49502f-6a5b-4502-8a42-2add9dd3d502 HTTP/1.1" 200 -
-2026-05-20T13:37:35.1948951Z ##[group]Run export E2E_TEST=1
-2026-05-20T13:37:35.1949263Z [36;1mexport E2E_TEST=1[0m
-2026-05-20T13:37:35.1949544Z [36;1mexport HEADNODE_URL=http://localhost:5000[0m
-2026-05-20T13:37:35.1949925Z [36;1mexport CLUSTER_CI_RUN_PATH=/usr/local/bin/cluster-ci-run[0m
-2026-05-20T13:37:35.1950316Z [36;1mexport PYTHONPATH=$PYTHONPATH:$(pwd)/src/scheduler[0m
-2026-05-20T13:37:35.1950651Z [36;1mpytest src/scheduler/tests/[0m
-2026-05-20T13:37:35.1984680Z shell: /usr/bin/bash -e {0}
-2026-05-20T13:37:35.1984903Z env:
-2026-05-20T13:37:35.1985140Z   pythonLocation: /opt/hostedtoolcache/Python/3.10.20/x64
-2026-05-20T13:37:35.1985554Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.20/x64/lib/pkgconfig
-2026-05-20T13:37:35.1985951Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.20/x64
-2026-05-20T13:37:35.1986311Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.20/x64
-2026-05-20T13:37:35.1986663Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.20/x64
-2026-05-20T13:37:35.1987052Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.20/x64/lib
-2026-05-20T13:37:35.1987347Z ##[endgroup]
-2026-05-20T13:37:35.9731076Z ============================= test session starts ==============================
-2026-05-20T13:37:35.9735048Z platform linux -- Python 3.10.20, pytest-9.0.3, pluggy-1.6.0
-2026-05-20T13:37:35.9735896Z rootdir: /home/runner/work/cluster-ci/cluster-ci
-2026-05-20T13:37:35.9736558Z configfile: pyproject.toml
-2026-05-20T13:37:35.9737453Z collected 21 items
-2026-05-20T13:37:35.9737774Z 
-2026-05-20T13:37:37.9958923Z src/scheduler/tests/test_commit_hash.py .                                [  4%]
-2026-05-20T13:37:40.0256353Z src/scheduler/tests/test_data_router.py ...                              [ 19%]
-2026-05-20T13:37:49.3029119Z src/scheduler/tests/test_derived_ram.py .                                [ 23%]
-2026-05-20T13:38:10.8300178Z src/scheduler/tests/test_flow.py ..                                      [ 33%]
-2026-05-20T13:38:10.8483670Z src/scheduler/tests/test_history_api.py .                                [ 38%]
-2026-05-20T13:38:10.8712957Z src/scheduler/tests/test_locality.py ..                                  [ 47%]
-2026-05-20T13:38:12.8991455Z src/scheduler/tests/test_portal.py .....                                 [ 71%]
-2026-05-20T13:38:12.9099622Z src/scheduler/tests/test_watchdog_logic.py ..                            [ 80%]
-2026-05-20T13:38:12.9692319Z src/scheduler/tests/test_worker_api.py ....                              [100%]
-2026-05-20T13:38:12.9692906Z 
-2026-05-20T13:38:12.9693133Z =============================== warnings summary ===============================
-2026-05-20T13:38:12.9694030Z src/scheduler/tests/test_derived_ram.py::TestDerivedRAM::test_derived_ram_calculation
-2026-05-20T13:38:12.9695878Z   /opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-12 (<lambda>)
-2026-05-20T13:38:12.9697148Z   
-2026-05-20T13:38:12.9697447Z   Traceback (most recent call last):
-2026-05-20T13:38:12.9706562Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/werkzeug/serving.py", line 760, in __init__
-2026-05-20T13:38:12.9707542Z       self.server_bind()
-2026-05-20T13:38:12.9708330Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/http/server.py", line 141, in server_bind
-2026-05-20T13:38:12.9709558Z       socketserver.TCPServer.server_bind(self)
-2026-05-20T13:38:12.9710445Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/socketserver.py", line 466, in server_bind
-2026-05-20T13:38:12.9711291Z       self.socket.bind(self.server_address)
-2026-05-20T13:38:12.9711774Z   OSError: [Errno 98] Address already in use
-2026-05-20T13:38:12.9712185Z   
-2026-05-20T13:38:12.9712620Z   During handling of the above exception, another exception occurred:
-2026-05-20T13:38:12.9713242Z   
-2026-05-20T13:38:12.9713519Z   Traceback (most recent call last):
-2026-05-20T13:38:12.9714878Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
-2026-05-20T13:38:12.9715733Z       self.run()
-2026-05-20T13:38:12.9716395Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/threading.py", line 953, in run
-2026-05-20T13:38:12.9717159Z       self._target(*self._args, **self._kwargs)
-2026-05-20T13:38:12.9718093Z     File "/home/runner/work/cluster-ci/cluster-ci/src/scheduler/tests/test_derived_ram.py", line 27, in <lambda>
-2026-05-20T13:38:12.9719293Z       cls.api_thread = threading.Thread(target=lambda: app.run(port=5002, debug=False, use_reloader=False))
-2026-05-20T13:38:12.9720489Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/flask/app.py", line 662, in run
-2026-05-20T13:38:12.9721403Z       run_simple(t.cast(str, host), port, self, **options)
-2026-05-20T13:38:12.9722408Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/werkzeug/serving.py", line 1094, in run_simple
-2026-05-20T13:38:12.9723323Z       srv = make_server(
-2026-05-20T13:38:12.9724442Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/werkzeug/serving.py", line 931, in make_server
-2026-05-20T13:38:12.9725376Z       return ThreadedWSGIServer(
-2026-05-20T13:38:12.9726239Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/werkzeug/serving.py", line 783, in __init__
-2026-05-20T13:38:12.9727115Z       sys.exit(1)
-2026-05-20T13:38:12.9727403Z   SystemExit: 1
-2026-05-20T13:38:12.9727675Z   
-2026-05-20T13:38:12.9728097Z   Enable tracemalloc to get traceback where the object was allocated.
-2026-05-20T13:38:12.9729061Z   See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
-2026-05-20T13:38:12.9730078Z     warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
-2026-05-20T13:38:12.9730576Z 
-2026-05-20T13:38:12.9730900Z -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-2026-05-20T13:38:12.9731655Z ======================== 21 passed, 1 warning in 37.31s ========================
-2026-05-20T13:38:13.0268210Z Post job cleanup.
-2026-05-20T13:38:13.1943518Z Post job cleanup.
-2026-05-20T13:38:13.2748767Z [command]/usr/bin/git version
-2026-05-20T13:38:13.2785086Z git version 2.54.0
-2026-05-20T13:38:13.2822787Z Temporarily overriding HOME='/home/runner/work/_temp/749e49d4-6345-4c84-b41c-0dca8752a2eb' before making global git config changes
-2026-05-20T13:38:13.2824523Z Adding repository directory to the temporary git global config as a safe directory
-2026-05-20T13:38:13.2829349Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/cluster-ci/cluster-ci
-2026-05-20T13:38:13.2863725Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
-2026-05-20T13:38:13.2896088Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
-2026-05-20T13:38:13.3147037Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
-2026-05-20T13:38:13.3171940Z http.https://github.com/.extraheader
-2026-05-20T13:38:13.3182825Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
-2026-05-20T13:38:13.3214920Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
-2026-05-20T13:38:13.3431599Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
-2026-05-20T13:38:13.3460392Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
-2026-05-20T13:38:13.3815364Z Cleaning up orphan processes
-2026-05-20T13:38:13.4114831Z Terminate orphan process: pid (2359) (python3)
-2026-05-20T13:38:13.4145568Z Terminate orphan process: pid (2360) (python3)
-2026-05-20T13:38:13.4177868Z Terminate orphan process: pid (2368) (python3)
-2026-05-20T13:38:13.4199637Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-python@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-05-20T11:48:42.3159583Z Current runner version: '2.334.0'
+2026-05-20T11:48:42.3164000Z Runner name: 'cluster-local-UNIL-DESI-slot2'
+2026-05-20T11:48:42.3164658Z Runner group name: 'default'
+2026-05-20T11:48:42.3165279Z Machine name: 'isipol09'
+2026-05-20T11:48:42.3169101Z ##[group]GITHUB_TOKEN Permissions
+2026-05-20T11:48:42.3170753Z Actions: write
+2026-05-20T11:48:42.3171228Z ArtifactMetadata: write
+2026-05-20T11:48:42.3171676Z Attestations: write
+2026-05-20T11:48:42.3172105Z Checks: write
+2026-05-20T11:48:42.3172496Z CodeQuality: write
+2026-05-20T11:48:42.3172897Z Contents: write
+2026-05-20T11:48:42.3173353Z Deployments: write
+2026-05-20T11:48:42.3173762Z Discussions: write
+2026-05-20T11:48:42.3174164Z Issues: write
+2026-05-20T11:48:42.3174517Z Metadata: read
+2026-05-20T11:48:42.3174914Z Models: read
+2026-05-20T11:48:42.3175280Z Packages: write
+2026-05-20T11:48:42.3175667Z Pages: write
+2026-05-20T11:48:42.3176047Z PullRequests: write
+2026-05-20T11:48:42.3176470Z RepositoryProjects: write
+2026-05-20T11:48:42.3177007Z SecurityEvents: write
+2026-05-20T11:48:42.3177455Z Statuses: write
+2026-05-20T11:48:42.3177851Z VulnerabilityAlerts: read
+2026-05-20T11:48:42.3178317Z ##[endgroup]
+2026-05-20T11:48:42.3179736Z Secret source: Actions
+2026-05-20T11:48:42.3180235Z Prepare workflow directory
+2026-05-20T11:48:42.3494341Z Prepare all required actions
+2026-05-20T11:48:42.3546880Z Getting action download info
+2026-05-20T11:48:42.8363527Z Download action repository 'actions/checkout@v5' (SHA:93cb6efe18208431cddfb8368fd83d5badbf9bfd)
+2026-05-20T11:48:43.2300497Z Complete job name: Execute Research Pipeline
+2026-05-20T11:48:43.2981622Z ##[group]Run actions/checkout@v5
+2026-05-20T11:48:43.2982257Z with:
+2026-05-20T11:48:43.2982582Z   fetch-depth: 0
+2026-05-20T11:48:43.2982958Z   repository: UNIL-DESI/cluster-ci
+2026-05-20T11:48:43.2983533Z   token: ***
+2026-05-20T11:48:43.2983866Z   ssh-strict: true
+2026-05-20T11:48:43.2984222Z   ssh-user: git
+2026-05-20T11:48:43.2984579Z   persist-credentials: true
+2026-05-20T11:48:43.2984981Z   clean: true
+2026-05-20T11:48:43.2985352Z   sparse-checkout-cone-mode: true
+2026-05-20T11:48:43.2985789Z   fetch-tags: false
+2026-05-20T11:48:43.2986147Z   show-progress: true
+2026-05-20T11:48:43.2986515Z   lfs: false
+2026-05-20T11:48:43.2986852Z   submodules: false
+2026-05-20T11:48:43.2987213Z   set-safe-directory: true
+2026-05-20T11:48:43.2987752Z ##[endgroup]
+2026-05-20T11:48:43.4879256Z Syncing repository: UNIL-DESI/cluster-ci
+2026-05-20T11:48:43.4882408Z ##[group]Getting Git version info
+2026-05-20T11:48:43.4883834Z Working directory is '/home/henri/cluster-ci/runners/slot2/_work/cluster-ci/cluster-ci'
+2026-05-20T11:48:43.4885721Z [command]/usr/bin/git version
+2026-05-20T11:48:43.4886464Z git version 2.25.1
+2026-05-20T11:48:43.4888902Z ##[endgroup]
+2026-05-20T11:48:43.4895196Z Copying '/home/henri/.gitconfig' to '/home/henri/cluster-ci/runners/slot2/_work/_temp/428fa45d-87c8-4101-a1a0-3f6bbd355ff4/.gitconfig'
+2026-05-20T11:48:43.4899091Z Temporarily overriding HOME='/home/henri/cluster-ci/runners/slot2/_work/_temp/428fa45d-87c8-4101-a1a0-3f6bbd355ff4' before making global git config changes
+2026-05-20T11:48:43.4901679Z Adding repository directory to the temporary git global config as a safe directory
+2026-05-20T11:48:43.4903173Z [command]/usr/bin/git config --global --add safe.directory /home/henri/cluster-ci/runners/slot2/_work/cluster-ci/cluster-ci
+2026-05-20T11:48:43.4905026Z [command]/usr/bin/git config --local --get remote.origin.url
+2026-05-20T11:48:43.4911028Z https://github.com/UNIL-DESI/cluster-ci
+2026-05-20T11:48:43.4923724Z ##[group]Removing previously created refs, to avoid conflicts
+2026-05-20T11:48:43.4928322Z [command]/usr/bin/git rev-parse --symbolic-full-name --verify --quiet HEAD
+2026-05-20T11:48:43.4943965Z refs/heads/cluster-draft/hjamet
+2026-05-20T11:48:43.4952846Z [command]/usr/bin/git checkout --detach
+2026-05-20T11:48:43.4980654Z HEAD is now at 5190600 Shadow commit for hjamet
+2026-05-20T11:48:43.5024281Z [command]/usr/bin/git branch --delete --force cluster-draft/hjamet
+2026-05-20T11:48:43.5050438Z Deleted branch cluster-draft/hjamet (was 5190600).
+2026-05-20T11:48:43.5095292Z ##[endgroup]
+2026-05-20T11:48:43.5099149Z [command]/usr/bin/git submodule status
+2026-05-20T11:48:43.5292566Z ##[group]Cleaning the repository
+2026-05-20T11:48:43.5296226Z [command]/usr/bin/git clean -ffdx
+2026-05-20T11:48:43.5324776Z [command]/usr/bin/git reset --hard HEAD
+2026-05-20T11:48:43.5352133Z HEAD is now at 5190600 Shadow commit for hjamet
+2026-05-20T11:48:43.5355772Z ##[endgroup]
+2026-05-20T11:48:43.5357944Z ##[group]Disabling automatic garbage collection
+2026-05-20T11:48:43.5362645Z [command]/usr/bin/git config --local gc.auto 0
+2026-05-20T11:48:43.5387328Z ##[endgroup]
+2026-05-20T11:48:43.5388327Z ##[group]Setting up auth
+2026-05-20T11:48:43.5394148Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-05-20T11:48:43.5423232Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-05-20T11:48:43.5621846Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-05-20T11:48:43.5649287Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-05-20T11:48:43.5855373Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-05-20T11:48:43.5880775Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-05-20T11:48:43.6059986Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-05-20T11:48:43.6099166Z ##[endgroup]
+2026-05-20T11:48:43.6100197Z ##[group]Fetching the repository
+2026-05-20T11:48:43.6112426Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+2026-05-20T11:48:43.9992328Z From https://github.com/UNIL-DESI/cluster-ci
+2026-05-20T11:48:43.9993910Z  - [deleted]         (none)     -> origin/cluster-draft/hjamet
+2026-05-20T11:48:44.1874423Z    597817f..fc0cea0  main       -> origin/main
+2026-05-20T11:48:44.1913378Z [command]/usr/bin/git branch --list --remote origin/main
+2026-05-20T11:48:44.1938803Z   origin/main
+2026-05-20T11:48:44.1948713Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+2026-05-20T11:48:44.1967511Z fc0cea0b2ab3951b9d97d8f8a0d97fa79991a676
+2026-05-20T11:48:44.1971604Z ##[endgroup]
+2026-05-20T11:48:44.1973954Z ##[group]Determining the checkout info
+2026-05-20T11:48:44.1976325Z ##[endgroup]
+2026-05-20T11:48:44.1978361Z ##[group]Checking out the ref
+2026-05-20T11:48:44.1980854Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2026-05-20T11:48:44.2013674Z Warning: you are leaving 1 commit behind, not connected to
+2026-05-20T11:48:44.2015212Z any of your branches:
+2026-05-20T11:48:44.2015897Z
+2026-05-20T11:48:44.2016335Z   5190600 Shadow commit for hjamet
+2026-05-20T11:48:44.2017146Z
+2026-05-20T11:48:44.2017994Z If you want to keep it by creating a new branch, this may be a good time
+2026-05-20T11:48:44.2019679Z to do so with:
+2026-05-20T11:48:44.2020222Z
+2026-05-20T11:48:44.2020719Z  git branch <new-branch-name> 5190600
+2026-05-20T11:48:44.2021600Z
+2026-05-20T11:48:44.2022065Z Switched to a new branch 'main'
+2026-05-20T11:48:44.2023610Z Branch 'main' set up to track remote branch 'main' from 'origin'.
+2026-05-20T11:48:44.2027199Z ##[endgroup]
+2026-05-20T11:48:44.2051857Z [command]/usr/bin/git log -1 --format=%H
+2026-05-20T11:48:44.2066868Z fc0cea0b2ab3951b9d97d8f8a0d97fa79991a676
+2026-05-20T11:48:44.2332638Z ##[group]Run /usr/local/bin/cluster-ci-run "UNIL-DESI/cluster-ci" "main" "***"
+2026-05-20T11:48:44.2335258Z [36;1m/usr/local/bin/cluster-ci-run "UNIL-DESI/cluster-ci" "main" "***"[0m
+2026-05-20T11:48:44.2353118Z shell: /usr/bin/bash -e {0}
+2026-05-20T11:48:44.2354149Z env:
+2026-05-20T11:48:44.2355441Z   ALL_GITHUB_SECRETS: {
+  "github_token": "***"
+}
+2026-05-20T11:48:44.2356524Z ##[endgroup]
+2026-05-20T11:48:44.2466079Z 🌐 Delegation Mode enabled. Submitting job to scheduler...
+2026-05-20T11:48:44.8233047Z 🚀 Submitting job for UNIL-DESI/cluster-ci@main (RAM: 2.0GB, Timeout: 24.0h, Custom App: False)
+2026-05-20T11:48:45.3422006Z ✅ Job submitted successfully! ID: 0acf873f-06d7-4c8d-a875-06137077b7fd
+2026-05-20T11:48:45.3423008Z ⏳ Waiting for job 0acf873f-06d7-4c8d-a875-06137077b7fd to complete...
+2026-05-20T11:48:45.3457592Z
+2026-05-20T11:48:47.3520096Z Status: pending...
+2026-05-20T11:48:49.3645840Z Status: pending...
+2026-05-20T11:48:49.3646254Z
+2026-05-20T11:48:49.3646813Z [Streaming logs from http://130.223.169.200:6000]
+2026-05-20T11:48:49.3647610Z ==========================================================================
+2026-05-20T11:48:49.3648856Z [2026-05-20 13:48:48] ℹ️  CLUSTER-CI: GitOps Runner Orchestration Start
+2026-05-20T11:48:49.3649961Z [2026-05-20 13:48:48] ℹ️     Target Repo   : UNIL-DESI/cluster-ci
+2026-05-20T11:48:49.3650877Z [2026-05-20 13:48:48] ℹ️     Target Branch : main
+2026-05-20T11:48:49.3652023Z [2026-05-20 13:48:48] ℹ️     Run Folder    : /home/henri/cluster-ci/repositories/UNIL-DESI/cluster-ci
+2026-05-20T11:48:49.3653067Z ==========================================================================
+2026-05-20T11:48:49.3653869Z ===STAGE:setup:BEGIN===
+2026-05-20T11:48:49.3654645Z [2026-05-20 13:48:48] ℹ️  [Step 1/3] Initializing local cache...
+2026-05-20T11:48:49.3655770Z [2026-05-20 13:48:48] ℹ️  [Step 1.5/3] JIT Garbage Collection (GC) Management...
+2026-05-20T11:48:49.3657206Z [2026-05-20 13:48:48] ℹ️  Preventive purge of containers for job 0acf873f-06d7-4c8d-a875-06137077b7fd...
+2026-05-20T11:48:49.3658517Z [2026-05-20 13:48:48] ℹ️  Scanning for zombie containers (JIT Zombie GC)...
+2026-05-20T11:48:51.3762563Z
+2026-05-20T11:48:51.3763853Z ❌ Job 0acf873f-06d7-4c8d-a875-06137077b7fd failed: Worker restarted while the job was running/assigned.
+2026-05-20T11:48:51.3935960Z ##[error]Process completed with exit code 158.
+2026-05-20T11:48:51.4071877Z Post job cleanup.
+2026-05-20T11:48:51.5605878Z [command]/usr/bin/git version
+2026-05-20T11:48:51.5633591Z git version 2.25.1
+2026-05-20T11:48:51.5656475Z Copying '/home/henri/.gitconfig' to '/home/henri/cluster-ci/runners/slot2/_work/_temp/580a683a-9b38-4779-a3a9-c56b3ad61006/.gitconfig'
+2026-05-20T11:48:51.5662798Z Temporarily overriding HOME='/home/henri/cluster-ci/runners/slot2/_work/_temp/580a683a-9b38-4779-a3a9-c56b3ad61006' before making global git config changes
+2026-05-20T11:48:51.5664341Z Adding repository directory to the temporary git global config as a safe directory
+2026-05-20T11:48:51.5666187Z [command]/usr/bin/git config --global --add safe.directory /home/henri/cluster-ci/runners/slot2/_work/cluster-ci/cluster-ci
+2026-05-20T11:48:51.5699564Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-05-20T11:48:51.5730689Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-05-20T11:48:51.5943885Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-05-20T11:48:51.5964143Z http.https://github.com/.extraheader
+2026-05-20T11:48:51.5976715Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2026-05-20T11:48:51.6005977Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-05-20T11:48:51.6206001Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-05-20T11:48:51.6233565Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-05-20T11:48:51.6556672Z Cleaning up orphan processes

--- a/ci.log
+++ b/ci.log
@@ -1,160 +1,99 @@
-2026-05-20T11:48:42.3159583Z Current runner version: '2.334.0'
-2026-05-20T11:48:42.3164000Z Runner name: 'cluster-local-UNIL-DESI-slot2'
-2026-05-20T11:48:42.3164658Z Runner group name: 'default'
-2026-05-20T11:48:42.3165279Z Machine name: 'isipol09'
-2026-05-20T11:48:42.3169101Z ##[group]GITHUB_TOKEN Permissions
-2026-05-20T11:48:42.3170753Z Actions: write
-2026-05-20T11:48:42.3171228Z ArtifactMetadata: write
-2026-05-20T11:48:42.3171676Z Attestations: write
-2026-05-20T11:48:42.3172105Z Checks: write
-2026-05-20T11:48:42.3172496Z CodeQuality: write
-2026-05-20T11:48:42.3172897Z Contents: write
-2026-05-20T11:48:42.3173353Z Deployments: write
-2026-05-20T11:48:42.3173762Z Discussions: write
-2026-05-20T11:48:42.3174164Z Issues: write
-2026-05-20T11:48:42.3174517Z Metadata: read
-2026-05-20T11:48:42.3174914Z Models: read
-2026-05-20T11:48:42.3175280Z Packages: write
-2026-05-20T11:48:42.3175667Z Pages: write
-2026-05-20T11:48:42.3176047Z PullRequests: write
-2026-05-20T11:48:42.3176470Z RepositoryProjects: write
-2026-05-20T11:48:42.3177007Z SecurityEvents: write
-2026-05-20T11:48:42.3177455Z Statuses: write
-2026-05-20T11:48:42.3177851Z VulnerabilityAlerts: read
-2026-05-20T11:48:42.3178317Z ##[endgroup]
-2026-05-20T11:48:42.3179736Z Secret source: Actions
-2026-05-20T11:48:42.3180235Z Prepare workflow directory
-2026-05-20T11:48:42.3494341Z Prepare all required actions
-2026-05-20T11:48:42.3546880Z Getting action download info
-2026-05-20T11:48:42.8363527Z Download action repository 'actions/checkout@v5' (SHA:93cb6efe18208431cddfb8368fd83d5badbf9bfd)
-2026-05-20T11:48:43.2300497Z Complete job name: Execute Research Pipeline
-2026-05-20T11:48:43.2981622Z ##[group]Run actions/checkout@v5
-2026-05-20T11:48:43.2982257Z with:
-2026-05-20T11:48:43.2982582Z   fetch-depth: 0
-2026-05-20T11:48:43.2982958Z   repository: UNIL-DESI/cluster-ci
-2026-05-20T11:48:43.2983533Z   token: ***
-2026-05-20T11:48:43.2983866Z   ssh-strict: true
-2026-05-20T11:48:43.2984222Z   ssh-user: git
-2026-05-20T11:48:43.2984579Z   persist-credentials: true
-2026-05-20T11:48:43.2984981Z   clean: true
-2026-05-20T11:48:43.2985352Z   sparse-checkout-cone-mode: true
-2026-05-20T11:48:43.2985789Z   fetch-tags: false
-2026-05-20T11:48:43.2986147Z   show-progress: true
-2026-05-20T11:48:43.2986515Z   lfs: false
-2026-05-20T11:48:43.2986852Z   submodules: false
-2026-05-20T11:48:43.2987213Z   set-safe-directory: true
-2026-05-20T11:48:43.2987752Z ##[endgroup]
-2026-05-20T11:48:43.4879256Z Syncing repository: UNIL-DESI/cluster-ci
-2026-05-20T11:48:43.4882408Z ##[group]Getting Git version info
-2026-05-20T11:48:43.4883834Z Working directory is '/home/henri/cluster-ci/runners/slot2/_work/cluster-ci/cluster-ci'
-2026-05-20T11:48:43.4885721Z [command]/usr/bin/git version
-2026-05-20T11:48:43.4886464Z git version 2.25.1
-2026-05-20T11:48:43.4888902Z ##[endgroup]
-2026-05-20T11:48:43.4895196Z Copying '/home/henri/.gitconfig' to '/home/henri/cluster-ci/runners/slot2/_work/_temp/428fa45d-87c8-4101-a1a0-3f6bbd355ff4/.gitconfig'
-2026-05-20T11:48:43.4899091Z Temporarily overriding HOME='/home/henri/cluster-ci/runners/slot2/_work/_temp/428fa45d-87c8-4101-a1a0-3f6bbd355ff4' before making global git config changes
-2026-05-20T11:48:43.4901679Z Adding repository directory to the temporary git global config as a safe directory
-2026-05-20T11:48:43.4903173Z [command]/usr/bin/git config --global --add safe.directory /home/henri/cluster-ci/runners/slot2/_work/cluster-ci/cluster-ci
-2026-05-20T11:48:43.4905026Z [command]/usr/bin/git config --local --get remote.origin.url
-2026-05-20T11:48:43.4911028Z https://github.com/UNIL-DESI/cluster-ci
-2026-05-20T11:48:43.4923724Z ##[group]Removing previously created refs, to avoid conflicts
-2026-05-20T11:48:43.4928322Z [command]/usr/bin/git rev-parse --symbolic-full-name --verify --quiet HEAD
-2026-05-20T11:48:43.4943965Z refs/heads/cluster-draft/hjamet
-2026-05-20T11:48:43.4952846Z [command]/usr/bin/git checkout --detach
-2026-05-20T11:48:43.4980654Z HEAD is now at 5190600 Shadow commit for hjamet
-2026-05-20T11:48:43.5024281Z [command]/usr/bin/git branch --delete --force cluster-draft/hjamet
-2026-05-20T11:48:43.5050438Z Deleted branch cluster-draft/hjamet (was 5190600).
-2026-05-20T11:48:43.5095292Z ##[endgroup]
-2026-05-20T11:48:43.5099149Z [command]/usr/bin/git submodule status
-2026-05-20T11:48:43.5292566Z ##[group]Cleaning the repository
-2026-05-20T11:48:43.5296226Z [command]/usr/bin/git clean -ffdx
-2026-05-20T11:48:43.5324776Z [command]/usr/bin/git reset --hard HEAD
-2026-05-20T11:48:43.5352133Z HEAD is now at 5190600 Shadow commit for hjamet
-2026-05-20T11:48:43.5355772Z ##[endgroup]
-2026-05-20T11:48:43.5357944Z ##[group]Disabling automatic garbage collection
-2026-05-20T11:48:43.5362645Z [command]/usr/bin/git config --local gc.auto 0
-2026-05-20T11:48:43.5387328Z ##[endgroup]
-2026-05-20T11:48:43.5388327Z ##[group]Setting up auth
-2026-05-20T11:48:43.5394148Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
-2026-05-20T11:48:43.5423232Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
-2026-05-20T11:48:43.5621846Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
-2026-05-20T11:48:43.5649287Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
-2026-05-20T11:48:43.5855373Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
-2026-05-20T11:48:43.5880775Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
-2026-05-20T11:48:43.6059986Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
-2026-05-20T11:48:43.6099166Z ##[endgroup]
-2026-05-20T11:48:43.6100197Z ##[group]Fetching the repository
-2026-05-20T11:48:43.6112426Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
-2026-05-20T11:48:43.9992328Z From https://github.com/UNIL-DESI/cluster-ci
-2026-05-20T11:48:43.9993910Z  - [deleted]         (none)     -> origin/cluster-draft/hjamet
-2026-05-20T11:48:44.1874423Z    597817f..fc0cea0  main       -> origin/main
-2026-05-20T11:48:44.1913378Z [command]/usr/bin/git branch --list --remote origin/main
-2026-05-20T11:48:44.1938803Z   origin/main
-2026-05-20T11:48:44.1948713Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
-2026-05-20T11:48:44.1967511Z fc0cea0b2ab3951b9d97d8f8a0d97fa79991a676
-2026-05-20T11:48:44.1971604Z ##[endgroup]
-2026-05-20T11:48:44.1973954Z ##[group]Determining the checkout info
-2026-05-20T11:48:44.1976325Z ##[endgroup]
-2026-05-20T11:48:44.1978361Z ##[group]Checking out the ref
-2026-05-20T11:48:44.1980854Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
-2026-05-20T11:48:44.2013674Z Warning: you are leaving 1 commit behind, not connected to
-2026-05-20T11:48:44.2015212Z any of your branches:
-2026-05-20T11:48:44.2015897Z 
-2026-05-20T11:48:44.2016335Z   5190600 Shadow commit for hjamet
-2026-05-20T11:48:44.2017146Z 
-2026-05-20T11:48:44.2017994Z If you want to keep it by creating a new branch, this may be a good time
-2026-05-20T11:48:44.2019679Z to do so with:
-2026-05-20T11:48:44.2020222Z 
-2026-05-20T11:48:44.2020719Z  git branch <new-branch-name> 5190600
-2026-05-20T11:48:44.2021600Z 
-2026-05-20T11:48:44.2022065Z Switched to a new branch 'main'
-2026-05-20T11:48:44.2023610Z Branch 'main' set up to track remote branch 'main' from 'origin'.
-2026-05-20T11:48:44.2027199Z ##[endgroup]
-2026-05-20T11:48:44.2051857Z [command]/usr/bin/git log -1 --format=%H
-2026-05-20T11:48:44.2066868Z fc0cea0b2ab3951b9d97d8f8a0d97fa79991a676
-2026-05-20T11:48:44.2332638Z ##[group]Run /usr/local/bin/cluster-ci-run "UNIL-DESI/cluster-ci" "main" "***"
-2026-05-20T11:48:44.2335258Z [36;1m/usr/local/bin/cluster-ci-run "UNIL-DESI/cluster-ci" "main" "***"[0m
-2026-05-20T11:48:44.2353118Z shell: /usr/bin/bash -e {0}
-2026-05-20T11:48:44.2354149Z env:
-2026-05-20T11:48:44.2355441Z   ALL_GITHUB_SECRETS: {
-  "github_token": "***"
-}
-2026-05-20T11:48:44.2356524Z ##[endgroup]
-2026-05-20T11:48:44.2466079Z 🌐 Delegation Mode enabled. Submitting job to scheduler...
-2026-05-20T11:48:44.8233047Z 🚀 Submitting job for UNIL-DESI/cluster-ci@main (RAM: 2.0GB, Timeout: 24.0h, Custom App: False)
-2026-05-20T11:48:45.3422006Z ✅ Job submitted successfully! ID: 0acf873f-06d7-4c8d-a875-06137077b7fd
-2026-05-20T11:48:45.3423008Z ⏳ Waiting for job 0acf873f-06d7-4c8d-a875-06137077b7fd to complete...
-2026-05-20T11:48:45.3457592Z 
-2026-05-20T11:48:47.3520096Z Status: pending... 
-2026-05-20T11:48:49.3645840Z Status: pending... 
-2026-05-20T11:48:49.3646254Z 
-2026-05-20T11:48:49.3646813Z [Streaming logs from http://130.223.169.200:6000]
-2026-05-20T11:48:49.3647610Z ==========================================================================
-2026-05-20T11:48:49.3648856Z [2026-05-20 13:48:48] ℹ️  CLUSTER-CI: GitOps Runner Orchestration Start
-2026-05-20T11:48:49.3649961Z [2026-05-20 13:48:48] ℹ️     Target Repo   : UNIL-DESI/cluster-ci
-2026-05-20T11:48:49.3650877Z [2026-05-20 13:48:48] ℹ️     Target Branch : main
-2026-05-20T11:48:49.3652023Z [2026-05-20 13:48:48] ℹ️     Run Folder    : /home/henri/cluster-ci/repositories/UNIL-DESI/cluster-ci
-2026-05-20T11:48:49.3653067Z ==========================================================================
-2026-05-20T11:48:49.3653869Z ===STAGE:setup:BEGIN===
-2026-05-20T11:48:49.3654645Z [2026-05-20 13:48:48] ℹ️  [Step 1/3] Initializing local cache...
-2026-05-20T11:48:49.3655770Z [2026-05-20 13:48:48] ℹ️  [Step 1.5/3] JIT Garbage Collection (GC) Management...
-2026-05-20T11:48:49.3657206Z [2026-05-20 13:48:48] ℹ️  Preventive purge of containers for job 0acf873f-06d7-4c8d-a875-06137077b7fd...
-2026-05-20T11:48:49.3658517Z [2026-05-20 13:48:48] ℹ️  Scanning for zombie containers (JIT Zombie GC)...
-2026-05-20T11:48:51.3762563Z 
-2026-05-20T11:48:51.3763853Z ❌ Job 0acf873f-06d7-4c8d-a875-06137077b7fd failed: Worker restarted while the job was running/assigned.
-2026-05-20T11:48:51.3935960Z ##[error]Process completed with exit code 158.
-2026-05-20T11:48:51.4071877Z Post job cleanup.
-2026-05-20T11:48:51.5605878Z [command]/usr/bin/git version
-2026-05-20T11:48:51.5633591Z git version 2.25.1
-2026-05-20T11:48:51.5656475Z Copying '/home/henri/.gitconfig' to '/home/henri/cluster-ci/runners/slot2/_work/_temp/580a683a-9b38-4779-a3a9-c56b3ad61006/.gitconfig'
-2026-05-20T11:48:51.5662798Z Temporarily overriding HOME='/home/henri/cluster-ci/runners/slot2/_work/_temp/580a683a-9b38-4779-a3a9-c56b3ad61006' before making global git config changes
-2026-05-20T11:48:51.5664341Z Adding repository directory to the temporary git global config as a safe directory
-2026-05-20T11:48:51.5666187Z [command]/usr/bin/git config --global --add safe.directory /home/henri/cluster-ci/runners/slot2/_work/cluster-ci/cluster-ci
-2026-05-20T11:48:51.5699564Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
-2026-05-20T11:48:51.5730689Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
-2026-05-20T11:48:51.5943885Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
-2026-05-20T11:48:51.5964143Z http.https://github.com/.extraheader
-2026-05-20T11:48:51.5976715Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
-2026-05-20T11:48:51.6005977Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
-2026-05-20T11:48:51.6206001Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
-2026-05-20T11:48:51.6233565Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
-2026-05-20T11:48:51.6556672Z Cleaning up orphan processes
+2026-05-20T13:37:25.4139622Z  * Serving Flask app 'worker_agent'
+2026-05-20T13:37:25.4140072Z  * Debug mode: off
+2026-05-20T13:37:25.4157362Z INFO:werkzeug:[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+2026-05-20T13:37:25.4173440Z  * Running on all addresses (0.0.0.0)
+2026-05-20T13:37:25.4173754Z  * Running on http://127.0.0.1:6000
+2026-05-20T13:37:25.4174024Z  * Running on http://10.1.0.207:6000
+2026-05-20T13:37:25.4174773Z INFO:werkzeug:[33mPress CTRL+C to quit[0m
+2026-05-20T13:37:25.4194427Z 127.0.0.1 - - [20/May/2026 13:37:25] "POST /register_worker HTTP/1.1" 200 -
+2026-05-20T13:37:25.4224412Z 127.0.0.1 - - [20/May/2026 13:37:25] "GET /worker_poll/ea49502f-6a5b-4502-8a42-2add9dd3d502 HTTP/1.1" 200 -
+2026-05-20T13:37:30.4311142Z 127.0.0.1 - - [20/May/2026 13:37:30] "GET /worker_poll/ea49502f-6a5b-4502-8a42-2add9dd3d502 HTTP/1.1" 200 -
+2026-05-20T13:37:35.1948951Z ##[group]Run export E2E_TEST=1
+2026-05-20T13:37:35.1949263Z [36;1mexport E2E_TEST=1[0m
+2026-05-20T13:37:35.1949544Z [36;1mexport HEADNODE_URL=http://localhost:5000[0m
+2026-05-20T13:37:35.1949925Z [36;1mexport CLUSTER_CI_RUN_PATH=/usr/local/bin/cluster-ci-run[0m
+2026-05-20T13:37:35.1950316Z [36;1mexport PYTHONPATH=$PYTHONPATH:$(pwd)/src/scheduler[0m
+2026-05-20T13:37:35.1950651Z [36;1mpytest src/scheduler/tests/[0m
+2026-05-20T13:37:35.1984680Z shell: /usr/bin/bash -e {0}
+2026-05-20T13:37:35.1984903Z env:
+2026-05-20T13:37:35.1985140Z   pythonLocation: /opt/hostedtoolcache/Python/3.10.20/x64
+2026-05-20T13:37:35.1985554Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.20/x64/lib/pkgconfig
+2026-05-20T13:37:35.1985951Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.20/x64
+2026-05-20T13:37:35.1986311Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.20/x64
+2026-05-20T13:37:35.1986663Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.20/x64
+2026-05-20T13:37:35.1987052Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.20/x64/lib
+2026-05-20T13:37:35.1987347Z ##[endgroup]
+2026-05-20T13:37:35.9731076Z ============================= test session starts ==============================
+2026-05-20T13:37:35.9735048Z platform linux -- Python 3.10.20, pytest-9.0.3, pluggy-1.6.0
+2026-05-20T13:37:35.9735896Z rootdir: /home/runner/work/cluster-ci/cluster-ci
+2026-05-20T13:37:35.9736558Z configfile: pyproject.toml
+2026-05-20T13:37:35.9737453Z collected 21 items
+2026-05-20T13:37:35.9737774Z 
+2026-05-20T13:37:37.9958923Z src/scheduler/tests/test_commit_hash.py .                                [  4%]
+2026-05-20T13:37:40.0256353Z src/scheduler/tests/test_data_router.py ...                              [ 19%]
+2026-05-20T13:37:49.3029119Z src/scheduler/tests/test_derived_ram.py .                                [ 23%]
+2026-05-20T13:38:10.8300178Z src/scheduler/tests/test_flow.py ..                                      [ 33%]
+2026-05-20T13:38:10.8483670Z src/scheduler/tests/test_history_api.py .                                [ 38%]
+2026-05-20T13:38:10.8712957Z src/scheduler/tests/test_locality.py ..                                  [ 47%]
+2026-05-20T13:38:12.8991455Z src/scheduler/tests/test_portal.py .....                                 [ 71%]
+2026-05-20T13:38:12.9099622Z src/scheduler/tests/test_watchdog_logic.py ..                            [ 80%]
+2026-05-20T13:38:12.9692319Z src/scheduler/tests/test_worker_api.py ....                              [100%]
+2026-05-20T13:38:12.9692906Z 
+2026-05-20T13:38:12.9693133Z =============================== warnings summary ===============================
+2026-05-20T13:38:12.9694030Z src/scheduler/tests/test_derived_ram.py::TestDerivedRAM::test_derived_ram_calculation
+2026-05-20T13:38:12.9695878Z   /opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-12 (<lambda>)
+2026-05-20T13:38:12.9697148Z   
+2026-05-20T13:38:12.9697447Z   Traceback (most recent call last):
+2026-05-20T13:38:12.9706562Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/werkzeug/serving.py", line 760, in __init__
+2026-05-20T13:38:12.9707542Z       self.server_bind()
+2026-05-20T13:38:12.9708330Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/http/server.py", line 141, in server_bind
+2026-05-20T13:38:12.9709558Z       socketserver.TCPServer.server_bind(self)
+2026-05-20T13:38:12.9710445Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/socketserver.py", line 466, in server_bind
+2026-05-20T13:38:12.9711291Z       self.socket.bind(self.server_address)
+2026-05-20T13:38:12.9711774Z   OSError: [Errno 98] Address already in use
+2026-05-20T13:38:12.9712185Z   
+2026-05-20T13:38:12.9712620Z   During handling of the above exception, another exception occurred:
+2026-05-20T13:38:12.9713242Z   
+2026-05-20T13:38:12.9713519Z   Traceback (most recent call last):
+2026-05-20T13:38:12.9714878Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
+2026-05-20T13:38:12.9715733Z       self.run()
+2026-05-20T13:38:12.9716395Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/threading.py", line 953, in run
+2026-05-20T13:38:12.9717159Z       self._target(*self._args, **self._kwargs)
+2026-05-20T13:38:12.9718093Z     File "/home/runner/work/cluster-ci/cluster-ci/src/scheduler/tests/test_derived_ram.py", line 27, in <lambda>
+2026-05-20T13:38:12.9719293Z       cls.api_thread = threading.Thread(target=lambda: app.run(port=5002, debug=False, use_reloader=False))
+2026-05-20T13:38:12.9720489Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/flask/app.py", line 662, in run
+2026-05-20T13:38:12.9721403Z       run_simple(t.cast(str, host), port, self, **options)
+2026-05-20T13:38:12.9722408Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/werkzeug/serving.py", line 1094, in run_simple
+2026-05-20T13:38:12.9723323Z       srv = make_server(
+2026-05-20T13:38:12.9724442Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/werkzeug/serving.py", line 931, in make_server
+2026-05-20T13:38:12.9725376Z       return ThreadedWSGIServer(
+2026-05-20T13:38:12.9726239Z     File "/opt/hostedtoolcache/Python/3.10.20/x64/lib/python3.10/site-packages/werkzeug/serving.py", line 783, in __init__
+2026-05-20T13:38:12.9727115Z       sys.exit(1)
+2026-05-20T13:38:12.9727403Z   SystemExit: 1
+2026-05-20T13:38:12.9727675Z   
+2026-05-20T13:38:12.9728097Z   Enable tracemalloc to get traceback where the object was allocated.
+2026-05-20T13:38:12.9729061Z   See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+2026-05-20T13:38:12.9730078Z     warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
+2026-05-20T13:38:12.9730576Z 
+2026-05-20T13:38:12.9730900Z -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+2026-05-20T13:38:12.9731655Z ======================== 21 passed, 1 warning in 37.31s ========================
+2026-05-20T13:38:13.0268210Z Post job cleanup.
+2026-05-20T13:38:13.1943518Z Post job cleanup.
+2026-05-20T13:38:13.2748767Z [command]/usr/bin/git version
+2026-05-20T13:38:13.2785086Z git version 2.54.0
+2026-05-20T13:38:13.2822787Z Temporarily overriding HOME='/home/runner/work/_temp/749e49d4-6345-4c84-b41c-0dca8752a2eb' before making global git config changes
+2026-05-20T13:38:13.2824523Z Adding repository directory to the temporary git global config as a safe directory
+2026-05-20T13:38:13.2829349Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/cluster-ci/cluster-ci
+2026-05-20T13:38:13.2863725Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-05-20T13:38:13.2896088Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-05-20T13:38:13.3147037Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-05-20T13:38:13.3171940Z http.https://github.com/.extraheader
+2026-05-20T13:38:13.3182825Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2026-05-20T13:38:13.3214920Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-05-20T13:38:13.3431599Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-05-20T13:38:13.3460392Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-05-20T13:38:13.3815364Z Cleaning up orphan processes
+2026-05-20T13:38:13.4114831Z Terminate orphan process: pid (2359) (python3)
+2026-05-20T13:38:13.4145568Z Terminate orphan process: pid (2360) (python3)
+2026-05-20T13:38:13.4177868Z Terminate orphan process: pid (2368) (python3)
+2026-05-20T13:38:13.4199637Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-python@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/src/scheduler/headnode_service.py
+++ b/src/scheduler/headnode_service.py
@@ -123,13 +123,20 @@ def register_worker():
         ''', (worker_id, hostname, service_url, total_ram_gb, total_ram_gb, total_storage_gb, available_storage_gb, hostname, service_url, total_ram_gb, total_storage_gb, available_storage_gb))
         
         # If a worker re-registers (is_startup=True), it means it restarted and lost any running jobs.
-        # We must mark any 'running' or 'assigned' jobs for this worker as 'failed'.
+        # We only fail 'running' jobs. Jobs that were merely 'assigned' are safely reverted to 'pending'
+        # so they can be rescheduled without falsely reporting a worker crash during assignment.
         is_startup = data.get('is_startup', False)
         if is_startup:
             cursor.execute('''
                 UPDATE jobs
                 SET status = 'failed', exit_code = COALESCE(exit_code, -98)
-                WHERE worker_id = ? AND status IN ('running', 'assigned')
+                WHERE worker_id = ? AND status = 'running'
+            ''', (worker_id,))
+
+            cursor.execute('''
+                UPDATE jobs
+                SET status = 'pending', worker_id = NULL
+                WHERE worker_id = ? AND status = 'assigned'
             ''', (worker_id,))
         
         conn.commit()

--- a/src/scheduler/tests/test_derived_ram.py
+++ b/src/scheduler/tests/test_derived_ram.py
@@ -17,14 +17,26 @@ from scheduler_loop import schedule_jobs
 class TestDerivedRAM(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.headnode_url = "http://localhost:5002"
         os.environ["CLUSTER_DB_PATH"] = "test_derived_ram.db"
         if os.path.exists("test_derived_ram.db"):
             os.remove("test_derived_ram.db")
         init_db()
 
-        # Start Headnode API in a thread
-        cls.api_thread = threading.Thread(target=lambda: app.run(port=5002, debug=False, use_reloader=False))
+        # Start Headnode API in a thread using werkzeug.serving for clean shutdown
+        from werkzeug.serving import make_server
+        import socket
+        def get_free_port():
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.bind(('', 0))
+            port = s.getsockname()[1]
+            s.close()
+            return port
+
+        cls.test_port = get_free_port()
+        cls.headnode_url = f"http://localhost:{cls.test_port}"
+
+        cls.server = make_server('0.0.0.0', cls.test_port, app)
+        cls.api_thread = threading.Thread(target=cls.server.serve_forever)
         cls.api_thread.daemon = True
         cls.api_thread.start()
 
@@ -88,6 +100,8 @@ class TestDerivedRAM(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.api_thread.join(timeout=5)
         try:
             if os.path.exists("test_derived_ram.db"):
                 os.remove("test_derived_ram.db")

--- a/src/scheduler/tests/test_flow.py
+++ b/src/scheduler/tests/test_flow.py
@@ -26,8 +26,21 @@ class TestScheduler(unittest.TestCase):
                 os.remove("test_cluster.db")
             init_db()
 
-            # Start Headnode API in a thread
-            cls.api_thread = threading.Thread(target=lambda: app.run(port=5001, debug=False, use_reloader=False))
+            # Start Headnode API in a thread using werkzeug.serving for clean shutdown
+            from werkzeug.serving import make_server
+            import socket
+            def get_free_port():
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.bind(('', 0))
+                port = s.getsockname()[1]
+                s.close()
+                return port
+
+            cls.test_port = get_free_port()
+            cls.headnode_url = f"http://localhost:{cls.test_port}"
+
+            cls.server = make_server('0.0.0.0', cls.test_port, app)
+            cls.api_thread = threading.Thread(target=cls.server.serve_forever)
             cls.api_thread.daemon = True
             cls.api_thread.start()
 
@@ -140,6 +153,8 @@ class TestScheduler(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if not cls.is_e2e:
+            cls.server.shutdown()
+            cls.api_thread.join(timeout=5)
             try:
                 if os.path.exists("test_cluster.db"):
                     os.remove("test_cluster.db")

--- a/src/scheduler/worker_agent.py
+++ b/src/scheduler/worker_agent.py
@@ -46,6 +46,7 @@ SERVICE_URL = os.environ.get("SERVICE_URL", f"http://{HOSTNAME}:{AGENT_PORT}")
 current_job_id = None
 current_process = None
 job_lock = threading.Lock()
+startup_heartbeat_event = threading.Event()
 
 def get_ram_info():
     mem = psutil.virtual_memory()
@@ -83,6 +84,7 @@ def heartbeat_loop():
             }, headers=get_headers(), timeout=10)
             resp.raise_for_status()
             is_startup = False
+            startup_heartbeat_event.set()
         except Exception as e:
             logger.error(f"Failed to send heartbeat: {e}")
         time.sleep(10)
@@ -621,6 +623,11 @@ def main_loop():
     
     # Start heartbeat in background thread
     threading.Thread(target=heartbeat_loop, daemon=True).start()
+
+    # Wait for the first heartbeat to be processed before polling for jobs
+    # This prevents a race condition where a job is fetched before the headnode
+    # knows the worker has restarted (which would kill the job with exit code -98).
+    startup_heartbeat_event.wait()
 
     while True:
         job = poll_for_job()

--- a/src/scheduler/worker_agent.py
+++ b/src/scheduler/worker_agent.py
@@ -627,7 +627,10 @@ def main_loop():
     # Wait for the first heartbeat to be processed before polling for jobs
     # This prevents a race condition where a job is fetched before the headnode
     # knows the worker has restarted (which would kill the job with exit code -98).
-    startup_heartbeat_event.wait()
+    # We add a 5-minute timeout to avoid infinite deadlocks if the headnode is completely unreachable.
+    if not startup_heartbeat_event.wait(timeout=300):
+        logger.error("Timeout: Failed to synchronize initial heartbeat with headnode after 5 minutes. Shutting down worker.")
+        sys.exit(1)
 
     while True:
         job = poll_for_job()


### PR DESCRIPTION
Fixes a race condition in the worker agent that incorrectly caused running jobs to fail with exit code `-98` (Worker restarted) if a job was polled before the worker's initial startup heartbeat was successfully processed by the headnode.

---
*PR created automatically by Jules for task [6389539907110468474](https://jules.google.com/task/6389539907110468474) started by @hjamet*