### PR TITLE
Auto-sync DVC metrics to Git via semantic heuristic

### DIFF
--- a/src/runner/dvc_git_helper.py
+++ b/src/runner/dvc_git_helper.py
@@ -92,23 +92,26 @@ def get_cache_false_paths(dvc_yaml_path):
     if not data:
         return []
 
-    def extract_from_entries(entries):
+    def extract_from_entries(entries, wdir='.'):
         if isinstance(entries, list):
             for entry in entries:
                 if isinstance(entry, dict):
                     for path, config in entry.items():
                         if isinstance(config, dict) and config.get('cache') is False:
-                            paths.add(path)
+                            full_path = os.path.join(wdir, path) if wdir != '.' else path
+                            paths.add(full_path)
         elif isinstance(entries, dict):
             for path, config in entries.items():
                 if isinstance(config, dict) and config.get('cache') is False:
-                    paths.add(path)
+                    full_path = os.path.join(wdir, path) if wdir != '.' else path
+                    paths.add(full_path)
 
     if 'stages' in data:
         for stage in data['stages'].values():
+            wdir = stage.get('wdir', '.')
             for key in ['metrics', 'plots']:
                 if key in stage:
-                    extract_from_entries(stage[key])
+                    extract_from_entries(stage[key], wdir)
 
     for key in ['metrics', 'plots']:
         if key in data:

--- a/src/runner/dvc_git_helper.py
+++ b/src/runner/dvc_git_helper.py
@@ -1,0 +1,170 @@
+import os
+import sys
+import argparse
+import subprocess
+from pathlib import Path
+
+try:
+    from ruamel.yaml import YAML
+except ImportError:
+    # We expect this to be run via uv run --with ruamel.yaml
+    pass
+
+def log_info(msg):
+    print(f"ℹ️  [DVC-Git-Helper] {msg}")
+
+def log_warn(msg):
+    print(f"⚠️  [DVC-Git-Helper] {msg}")
+
+def log_success(msg):
+    print(f"✅ [DVC-Git-Helper] {msg}")
+
+def inject_cache_false(dvc_yaml_path):
+    if not os.path.exists(dvc_yaml_path):
+        log_info(f"{dvc_yaml_path} not found, skipping injection.")
+        return
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with open(dvc_yaml_path, 'r') as f:
+        data = yaml.load(f)
+
+    if not data:
+        log_info("Empty dvc.yaml.")
+        return
+
+    modified = False
+
+    def process_entries(entries, container, key_in_container):
+        nonlocal modified
+        if isinstance(entries, list):
+            for i, entry in enumerate(entries):
+                if isinstance(entry, str):
+                    container[key_in_container][i] = {entry: {'cache': False}}
+                    modified = True
+                elif isinstance(entry, dict):
+                    for filename, config in entry.items():
+                        if isinstance(config, dict):
+                            if config.get('cache') is not False:
+                                config['cache'] = False
+                                modified = True
+                        else:
+                            entry[filename] = {'cache': False}
+                            modified = True
+        elif isinstance(entries, dict):
+            for filename, config in entries.items():
+                if isinstance(config, dict):
+                    if config.get('cache') is not False:
+                        config['cache'] = False
+                        modified = True
+                else:
+                    entries[filename] = {'cache': False}
+                    modified = True
+
+    # Process stages
+    if 'stages' in data:
+        for stage_name, stage in data['stages'].items():
+            for key in ['metrics', 'plots']:
+                if key in stage:
+                    process_entries(stage[key], stage, key)
+
+    # Process top-level metrics and plots
+    for key in ['metrics', 'plots']:
+        if key in data:
+            process_entries(data[key], data, key)
+
+    if modified:
+        with open(dvc_yaml_path, 'w') as f:
+            yaml.dump(data, f)
+        log_success(f"Injected 'cache: false' into {dvc_yaml_path} metrics/plots.")
+    else:
+        log_info("No changes needed in dvc.yaml.")
+
+def get_cache_false_paths(dvc_yaml_path):
+    if not os.path.exists(dvc_yaml_path):
+        return []
+
+    yaml = YAML()
+    with open(dvc_yaml_path, 'r') as f:
+        data = yaml.load(f)
+
+    paths = set()
+    if not data:
+        return []
+
+    def extract_from_entries(entries):
+        if isinstance(entries, list):
+            for entry in entries:
+                if isinstance(entry, dict):
+                    for path, config in entry.items():
+                        if isinstance(config, dict) and config.get('cache') is False:
+                            paths.add(path)
+        elif isinstance(entries, dict):
+            for path, config in entries.items():
+                if isinstance(config, dict) and config.get('cache') is False:
+                    paths.add(path)
+
+    if 'stages' in data:
+        for stage in data['stages'].values():
+            for key in ['metrics', 'plots']:
+                if key in stage:
+                    extract_from_entries(stage[key])
+
+    for key in ['metrics', 'plots']:
+        if key in data:
+            extract_from_entries(data[key])
+
+    return list(paths)
+
+def sync_metrics():
+    dvc_yaml_path = 'dvc.yaml'
+    paths = get_cache_false_paths(dvc_yaml_path)
+
+    if not paths:
+        log_info("No metrics/plots with cache: false found to sync.")
+        return
+
+    added_any = False
+    for path in paths:
+        if not os.path.isfile(path):
+            continue
+
+        size_mb = os.path.getsize(path) / (1024 * 1024)
+        if size_mb < 5:
+            subprocess.run(['git', 'add', path], check=True)
+            log_info(f"Staged {path} ({size_mb:.2f} MB)")
+            added_any = True
+        else:
+            log_warn(f"WARNING: Le fichier {path} (déclaré comme metric/plot) dépasse 5 Mo. Il ne sera synchronisé ni sur Git, ni sur le réseau P2P. Si vous souhaitez conserver ce fichier, déplacez-le sous la clé outs: dans votre dvc.yaml.")
+
+    if added_any:
+        # Check if there are actual changes staged
+        res = subprocess.run(['git', 'diff', '--cached', '--quiet'])
+        if res.returncode != 0:
+            log_info("Committing and pushing auto-synced metrics...")
+            subprocess.run(['git', 'config', 'user.name', 'cluster-ci-bot'], check=True)
+            subprocess.run(['git', 'config', 'user.email', 'bot@cluster-ci.io'], check=True)
+            subprocess.run(['git', 'commit', '-m', 'chore(ci): auto-sync metrics [skip ci]'], check=True)
+            # Try to push to current branch
+            subprocess.run(['git', 'push', 'origin', 'HEAD'], check=True)
+            log_success("Metrics synced successfully.")
+        else:
+            log_info("No changes to commit.")
+    else:
+        log_info("No valid files to sync found.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='command')
+
+    subparsers.add_parser('inject')
+    subparsers.add_parser('sync')
+
+    args = parser.parse_args()
+
+    if args.command == 'inject':
+        inject_cache_false('dvc.yaml')
+    elif args.command == 'sync':
+        sync_metrics()
+    else:
+        parser.print_help()

--- a/src/runner/run_research_pipeline.sh
+++ b/src/runner/run_research_pipeline.sh
@@ -442,6 +442,9 @@ log_info "Pre-flight Validation..."
 # Run the validation script using uv to ensure dependencies (tomlkit) are present
 docker_exec "uv run --with tomlkit python3 /cluster-ci/src/runner/validate_pyproject.py --ci"
 
+log_info "DVC-Git-Helper: Injecting cache: false for metrics and plots..."
+docker_exec "uv run --with ruamel.yaml python3 /cluster-ci/src/runner/dvc_git_helper.py inject"
+
 echo "===STAGE:setup:END==="
 echo "===STAGE:dvc_repro:BEGIN==="
 
@@ -616,6 +619,9 @@ echo "===STAGE:sync:BEGIN==="
 if [ $EXEC_RET -ne 0 ]; then
     log_error "Execution interrupted or failed (Exit code: $EXEC_RET). Forcing DVC sync before exiting..."
 fi
+
+log_info "DVC-Git-Helper: Syncing metrics and plots to Git..."
+uv run --with ruamel.yaml python3 "$BASE_DIR/src/runner/dvc_git_helper.py" sync || log_warn "DVC-Git-Helper sync failed."
 
 # Step 4 (Data Router) removed in favor of Post-Flight Lazy Transfer GC.
 

--- a/src/runner/test_dvc_git_helper.py
+++ b/src/runner/test_dvc_git_helper.py
@@ -78,5 +78,20 @@ class TestDVCGitHelper(unittest.TestCase):
         self.assertIn('p1.csv', paths)
         self.assertNotIn('m2.json', paths)
 
+    def test_get_paths_with_wdir(self):
+        content = {
+            'stages': {
+                'train': {
+                    'wdir': 'results',
+                    'metrics': [{'m1.json': {'cache': False}}]
+                }
+            }
+        }
+        with open(self.dvc_yaml, 'w') as f:
+            self.yaml.dump(content, f)
+
+        paths = get_cache_false_paths(self.dvc_yaml)
+        self.assertIn('results/m1.json', paths)
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/runner/test_dvc_git_helper.py
+++ b/src/runner/test_dvc_git_helper.py
@@ -1,0 +1,82 @@
+import unittest
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from ruamel.yaml import YAML
+
+# Add src to sys.path to import dvc_git_helper
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+from src.runner.dvc_git_helper import inject_cache_false, get_cache_false_paths
+
+class TestDVCGitHelper(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.dvc_yaml = os.path.join(self.test_dir, 'dvc.yaml')
+        self.yaml = YAML()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_inject_shorthand(self):
+        content = {
+            'stages': {
+                'train': {
+                    'cmd': 'python train.py',
+                    'metrics': ['metrics.json'],
+                    'plots': ['plots.csv']
+                }
+            }
+        }
+        with open(self.dvc_yaml, 'w') as f:
+            self.yaml.dump(content, f)
+
+        inject_cache_false(self.dvc_yaml)
+
+        with open(self.dvc_yaml, 'r') as f:
+            data = self.yaml.load(f)
+
+        self.assertEqual(data['stages']['train']['metrics'][0]['metrics.json']['cache'], False)
+        self.assertEqual(data['stages']['train']['plots'][0]['plots.csv']['cache'], False)
+
+    def test_inject_longhand(self):
+        content = {
+            'stages': {
+                'train': {
+                    'cmd': 'python train.py',
+                    'metrics': [{'metrics.json': {'cache': True}}],
+                    'plots': [{'plots.csv': {}}]
+                }
+            }
+        }
+        with open(self.dvc_yaml, 'w') as f:
+            self.yaml.dump(content, f)
+
+        inject_cache_false(self.dvc_yaml)
+
+        with open(self.dvc_yaml, 'r') as f:
+            data = self.yaml.load(f)
+
+        self.assertEqual(data['stages']['train']['metrics'][0]['metrics.json']['cache'], False)
+        self.assertEqual(data['stages']['train']['plots'][0]['plots.csv']['cache'], False)
+
+    def test_get_paths(self):
+        content = {
+            'stages': {
+                'train': {
+                    'metrics': [{'m1.json': {'cache': False}}, {'m2.json': {'cache': True}}],
+                    'plots': [{'p1.csv': {'cache': False}}]
+                }
+            }
+        }
+        with open(self.dvc_yaml, 'w') as f:
+            self.yaml.dump(content, f)
+
+        paths = get_cache_false_paths(self.dvc_yaml)
+        self.assertIn('m1.json', paths)
+        self.assertIn('p1.csv', paths)
+        self.assertNotIn('m2.json', paths)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces an automated mechanism to synchronize DVC metrics and plots directly to Git. 

Key features:
- **Semantic Injection**: Before running `dvc repro`, the system now parses `dvc.yaml` and sets `cache: false` for all entries under `metrics` and `plots` (both at stage level and top-level). This ensures these files are not managed by DVC's cache but are available for Git.
- **Automated Git Sync**: At the end of the research pipeline, files identified as metrics or plots that are under 5MB are automatically staged, committed with `chore(ci): auto-sync metrics [skip ci]`, and pushed to the current branch.
- **Safety**: 
    - Files larger than 5MB are skipped with a clear warning to avoid bloating the Git history.
    - `ruamel.yaml` is used to preserve the original formatting and comments in `dvc.yaml`.
    - `[skip ci]` is used to prevent recursive CI runs.
- **Resilience**: The sync step is integrated into the final stage of the pipeline and will run even if the main execution fails, capturing partial results.


Fixes #86

---
*PR created automatically by Jules for task [16563012197513185104](https://jules.google.com/task/16563012197513185104) started by @hjamet*